### PR TITLE
Implement REST API v1 — event log/audit trail endpoint

### DIFF
--- a/docs/superpowers/plans/2026-05-08-event-log-endpoint.md
+++ b/docs/superpowers/plans/2026-05-08-event-log-endpoint.md
@@ -1,0 +1,1499 @@
+# Event Log Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `GET /api/v1/cases/{caseId}/events` REST endpoint with pagination and filtering for case event logs.
+
+**Architecture:** Three-layer architecture with EventLogEntryResponse DTO, EventLogService for business logic (pagination, filtering, enum conversion), and EventLogResource REST controller. Uses existing CaseHubRuntime for data access.
+
+**Tech Stack:** Quarkus REST, SmallRye Mutiny (Uni), Jackson (JsonNode), JUnit 5, AssertJ, Mockito, RestAssured
+
+---
+
+## File Structure
+
+**New Files:**
+- `src/main/java/io/casehub/flow/rest/dto/EventLogEntryResponse.java` - DTO for event log entries
+- `src/main/java/io/casehub/flow/service/EventLogService.java` - Business logic for event log operations
+- `src/main/java/io/casehub/flow/rest/EventLogResource.java` - REST endpoint
+- `src/test/java/io/casehub/flow/service/EventLogServiceTest.java` - Unit tests for service
+- `src/test/java/io/casehub/flow/rest/EventLogResourceIT.java` - Integration tests
+
+**Modified Files:** None
+
+---
+
+### Task 1: Create EventLogEntryResponse DTO
+
+**Files:**
+- Create: `src/main/java/io/casehub/flow/rest/dto/EventLogEntryResponse.java`
+
+- [ ] **Step 1: Create EventLogEntryResponse record**
+
+```java
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+/**
+ * Event log entry response DTO.
+ *
+ * <p>Represents a single event from the case event log, mapping directly from
+ * CaseEventLogRecord.
+ *
+ * @param eventType type of event
+ * @param streamType stream classification (CONTROL, DATA, etc.)
+ * @param timestamp when the event occurred
+ * @param payload event-specific data
+ * @param metadata event metadata (traceId, etc.)
+ */
+public record EventLogEntryResponse(
+    @NotNull CaseHubEventType eventType,
+    @NotNull EventStreamType streamType,
+    @NotNull Instant timestamp,
+    JsonNode payload,
+    JsonNode metadata) {}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `mvn compile -DskipTests`
+Expected: SUCCESS
+
+- [ ] **Step 3: Commit DTO**
+
+```bash
+git add src/main/java/io/casehub/flow/rest/dto/EventLogEntryResponse.java
+git commit -m "feat: add EventLogEntryResponse DTO for event log entries
+
+Add record DTO mapping directly from CaseEventLogRecord with fields:
+eventType, streamType, timestamp, payload, metadata.
+
+Issue: #7"
+```
+
+---
+
+### Task 2: EventLogService - Setup and Enum Conversion
+
+**Files:**
+- Create: `src/main/java/io/casehub/flow/service/EventLogService.java`
+- Create: `src/test/java/io/casehub/flow/service/EventLogServiceTest.java`
+
+- [ ] **Step 1: Write test for valid enum conversion**
+
+```java
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class EventLogServiceTest {
+
+  private final EventLogService service = new EventLogService();
+
+  @Test
+  void convertEventTypes_withValidValues_returnsEnumSet() {
+    List<String> input = List.of("WORKER_EXECUTION_COMPLETED", "STATE_CHANGED");
+
+    Set<CaseHubEventType> result = service.convertEventTypes(input);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder(
+            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+            CaseHubEventType.STATE_CHANGED);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=EventLogServiceTest#convertEventTypes_withValidValues_returnsEnumSet`
+Expected: FAIL - "EventLogService does not exist"
+
+- [ ] **Step 3: Create EventLogService with enum conversion**
+
+```java
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.service;
+
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Service for event log operations.
+ *
+ * <p>Provides business logic for retrieving, filtering, and paginating case event logs.
+ */
+@ApplicationScoped
+public class EventLogService {
+
+  /**
+   * Convert string event type names to enum set.
+   *
+   * @param eventTypeNames list of event type names
+   * @return set of CaseHubEventType enums
+   * @throws IllegalArgumentException if any name is invalid
+   */
+  public Set<CaseHubEventType> convertEventTypes(List<String> eventTypeNames) {
+    if (eventTypeNames == null || eventTypeNames.isEmpty()) {
+      return Set.of();
+    }
+    return eventTypeNames.stream()
+        .map(name -> CaseHubEventType.valueOf(name))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Convert string stream type names to enum set.
+   *
+   * @param streamTypeNames list of stream type names
+   * @return set of EventStreamType enums
+   * @throws IllegalArgumentException if any name is invalid
+   */
+  public Set<EventStreamType> convertStreamTypes(List<String> streamTypeNames) {
+    if (streamTypeNames == null || streamTypeNames.isEmpty()) {
+      return Set.of();
+    }
+    return streamTypeNames.stream()
+        .map(name -> EventStreamType.valueOf(name))
+        .collect(Collectors.toSet());
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=EventLogServiceTest#convertEventTypes_withValidValues_returnsEnumSet`
+Expected: PASS
+
+- [ ] **Step 5: Write test for invalid enum conversion**
+
+Add to `EventLogServiceTest`:
+
+```java
+  @Test
+  void convertEventTypes_withInvalidValue_throwsIllegalArgumentException() {
+    List<String> input = List.of("INVALID_EVENT_TYPE");
+
+    assertThatThrownBy(() -> service.convertEventTypes(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("INVALID_EVENT_TYPE");
+  }
+
+  @Test
+  void convertStreamTypes_withValidValues_returnsEnumSet() {
+    List<String> input = List.of("CONTROL", "DATA");
+
+    Set<EventStreamType> result = service.convertStreamTypes(input);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder(
+            EventStreamType.CONTROL,
+            EventStreamType.DATA);
+  }
+
+  @Test
+  void convertStreamTypes_withInvalidValue_throwsIllegalArgumentException() {
+    List<String> input = List.of("INVALID_STREAM");
+
+    assertThatThrownBy(() -> service.convertStreamTypes(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("INVALID_STREAM");
+  }
+
+  @Test
+  void convertEventTypes_withNullOrEmpty_returnsEmptySet() {
+    assertThat(service.convertEventTypes(null)).isEmpty();
+    assertThat(service.convertEventTypes(List.of())).isEmpty();
+  }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogServiceTest`
+Expected: All 5 tests PASS
+
+- [ ] **Step 7: Commit enum conversion**
+
+```bash
+git add src/main/java/io/casehub/flow/service/EventLogService.java
+git add src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+git commit -m "feat: add EventLogService with enum conversion helpers
+
+Add service with convertEventTypes and convertStreamTypes methods
+for converting query param strings to enum sets. Includes validation
+that throws IllegalArgumentException for invalid enum values.
+
+Issue: #7"
+```
+
+---
+
+### Task 3: EventLogService - Basic Event Fetching and Mapping
+
+**Files:**
+- Modify: `src/main/java/io/casehub/flow/service/EventLogService.java`
+- Modify: `src/test/java/io/casehub/flow/service/EventLogServiceTest.java`
+
+- [ ] **Step 1: Write test for basic event fetching without filters**
+
+Add to `EventLogServiceTest`:
+
+```java
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.casehub.api.engine.CaseHubRuntime;
+import io.casehub.api.model.event.CaseEventLogRecord;
+import io.casehub.flow.rest.dto.EventLogEntryResponse;
+import io.casehub.flow.rest.dto.PagedResponse;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+
+class EventLogServiceTest {
+
+  private CaseHubRuntime runtime;
+  private EventLogService service;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    runtime = mock(CaseHubRuntime.class);
+    service = new EventLogService();
+    service.caseHubRuntime = runtime;
+  }
+
+  @Test
+  void getEventLog_noFiltersNoPagination_returnsAllEvents() {
+    UUID caseId = UUID.randomUUID();
+    Instant now = Instant.now();
+    ObjectNode payload = objectMapper.createObjectNode().put("key", "value");
+    ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "abc");
+
+    List<CaseEventLogRecord> records = List.of(
+        new CaseEventLogRecord(
+            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+            EventStreamType.CONTROL,
+            now,
+            payload,
+            metadata));
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(records));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 1, 50, null, null).await().indefinitely();
+
+    assertThat(result.content()).hasSize(1);
+    assertThat(result.content().get(0).eventType())
+        .isEqualTo(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+    assertThat(result.content().get(0).streamType())
+        .isEqualTo(EventStreamType.CONTROL);
+    assertThat(result.content().get(0).timestamp()).isEqualTo(now);
+    assertThat(result.content().get(0).payload()).isEqualTo(payload);
+    assertThat(result.content().get(0).metadata()).isEqualTo(metadata);
+    assertThat(result.page()).isEqualTo(1);
+    assertThat(result.size()).isEqualTo(50);
+    assertThat(result.totalElements()).isEqualTo(1);
+    assertThat(result.totalPages()).isEqualTo(1);
+
+    verify(runtime).eventLog(caseId);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=EventLogServiceTest#getEventLog_noFiltersNoPagination_returnsAllEvents`
+Expected: FAIL - "getEventLog method does not exist"
+
+- [ ] **Step 3: Implement getEventLog with basic fetching and mapping**
+
+Add to `EventLogService`:
+
+```java
+import io.casehub.api.engine.CaseHubRuntime;
+import io.casehub.api.model.event.CaseEventLogRecord;
+import io.casehub.flow.rest.dto.EventLogEntryResponse;
+import io.casehub.flow.rest.dto.PagedResponse;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.util.UUID;
+
+@ApplicationScoped
+public class EventLogService {
+
+  @Inject CaseHubRuntime caseHubRuntime;
+
+  /**
+   * Get paginated and filtered event log for a case.
+   *
+   * @param caseId case instance UUID
+   * @param page page number (1-indexed)
+   * @param size page size
+   * @param eventTypeNames optional event type filter
+   * @param streamTypeNames optional stream type filter
+   * @return paged response with event log entries
+   */
+  public Uni<PagedResponse<EventLogEntryResponse>> getEventLog(
+      UUID caseId,
+      int page,
+      int size,
+      List<String> eventTypeNames,
+      List<String> streamTypeNames) {
+
+    // Convert filter strings to enums
+    Set<CaseHubEventType> eventTypes = convertEventTypes(eventTypeNames);
+    Set<EventStreamType> streamTypes = convertStreamTypes(streamTypeNames);
+
+    // Choose appropriate runtime method based on filters
+    CompletionStage<List<CaseEventLogRecord>> eventLogFuture;
+    if (!eventTypes.isEmpty() && !streamTypes.isEmpty()) {
+      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes, streamTypes);
+    } else if (!eventTypes.isEmpty()) {
+      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes);
+    } else {
+      eventLogFuture = caseHubRuntime.eventLog(caseId);
+    }
+
+    return Uni.createFrom()
+        .completionStage(eventLogFuture)
+        .map(events -> buildPagedResponse(events, page, size));
+  }
+
+  /**
+   * Build paged response from event list.
+   *
+   * @param allEvents all events (after filtering)
+   * @param page page number (1-indexed)
+   * @param size page size
+   * @return paged response
+   */
+  private PagedResponse<EventLogEntryResponse> buildPagedResponse(
+      List<CaseEventLogRecord> allEvents, int page, int size) {
+
+    int totalElements = allEvents.size();
+    int totalPages = (totalElements + size - 1) / size;
+
+    // Calculate pagination bounds
+    int offset = (page - 1) * size;
+    int endIndex = Math.min(offset + size, totalElements);
+
+    // Handle out-of-bounds page (return empty)
+    List<EventLogEntryResponse> content;
+    if (offset >= totalElements) {
+      content = List.of();
+    } else {
+      content = allEvents.subList(offset, endIndex).stream()
+          .map(this::toEventLogEntryResponse)
+          .toList();
+    }
+
+    return new PagedResponse<>(content, page, size, totalElements, totalPages);
+  }
+
+  /**
+   * Map CaseEventLogRecord to EventLogEntryResponse.
+   *
+   * @param record event log record from engine
+   * @return response DTO
+   */
+  private EventLogEntryResponse toEventLogEntryResponse(CaseEventLogRecord record) {
+    return new EventLogEntryResponse(
+        record.eventType(),
+        record.streamType(),
+        record.timestamp(),
+        record.payload(),
+        record.metadata());
+  }
+
+  // ... existing convertEventTypes and convertStreamTypes methods ...
+}
+```
+
+Add import:
+```java
+import java.util.concurrent.CompletionStage;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=EventLogServiceTest#getEventLog_noFiltersNoPagination_returnsAllEvents`
+Expected: PASS
+
+- [ ] **Step 5: Commit basic event fetching**
+
+```bash
+git add src/main/java/io/casehub/flow/service/EventLogService.java
+git add src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+git commit -m "feat: add basic event log fetching and mapping
+
+Implement getEventLog method that fetches events from CaseHubRuntime,
+maps to EventLogEntryResponse DTOs, and builds PagedResponse. Includes
+helper methods for pagination math and DTO mapping.
+
+Issue: #7"
+```
+
+---
+
+### Task 4: EventLogService - Pagination Logic
+
+**Files:**
+- Modify: `src/test/java/io/casehub/flow/service/EventLogServiceTest.java`
+
+- [ ] **Step 1: Write test for first page pagination**
+
+Add to `EventLogServiceTest`:
+
+```java
+  @Test
+  void getEventLog_firstPage_returnsCorrectSubset() {
+    UUID caseId = UUID.randomUUID();
+    List<CaseEventLogRecord> records = createMockRecords(100);
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(records));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 1, 10, null, null).await().indefinitely();
+
+    assertThat(result.content()).hasSize(10);
+    assertThat(result.page()).isEqualTo(1);
+    assertThat(result.size()).isEqualTo(10);
+    assertThat(result.totalElements()).isEqualTo(100);
+    assertThat(result.totalPages()).isEqualTo(10);
+  }
+
+  @Test
+  void getEventLog_middlePage_returnsCorrectSubset() {
+    UUID caseId = UUID.randomUUID();
+    List<CaseEventLogRecord> records = createMockRecords(100);
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(records));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 5, 10, null, null).await().indefinitely();
+
+    assertThat(result.content()).hasSize(10);
+    assertThat(result.page()).isEqualTo(5);
+    assertThat(result.totalElements()).isEqualTo(100);
+    assertThat(result.totalPages()).isEqualTo(10);
+  }
+
+  @Test
+  void getEventLog_lastPage_returnsPartialSubset() {
+    UUID caseId = UUID.randomUUID();
+    List<CaseEventLogRecord> records = createMockRecords(95);
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(records));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 10, 10, null, null).await().indefinitely();
+
+    assertThat(result.content()).hasSize(5);  // Last page has 5 items
+    assertThat(result.page()).isEqualTo(10);
+    assertThat(result.totalElements()).isEqualTo(95);
+    assertThat(result.totalPages()).isEqualTo(10);
+  }
+
+  @Test
+  void getEventLog_pageBeyondTotal_returnsEmptyPage() {
+    UUID caseId = UUID.randomUUID();
+    List<CaseEventLogRecord> records = createMockRecords(10);
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(records));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 5, 10, null, null).await().indefinitely();
+
+    assertThat(result.content()).isEmpty();
+    assertThat(result.page()).isEqualTo(5);
+    assertThat(result.totalElements()).isEqualTo(10);
+    assertThat(result.totalPages()).isEqualTo(1);
+  }
+
+  @Test
+  void getEventLog_emptyEventLog_returnsEmptyPage() {
+    UUID caseId = UUID.randomUUID();
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 1, 50, null, null).await().indefinitely();
+
+    assertThat(result.content()).isEmpty();
+    assertThat(result.totalElements()).isEqualTo(0);
+    assertThat(result.totalPages()).isEqualTo(0);
+  }
+
+  private List<CaseEventLogRecord> createMockRecords(int count) {
+    ObjectNode payload = objectMapper.createObjectNode().put("index", 0);
+    ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "test");
+    
+    return java.util.stream.IntStream.range(0, count)
+        .mapToObj(i -> new CaseEventLogRecord(
+            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+            EventStreamType.CONTROL,
+            Instant.now().plusSeconds(i),
+            payload,
+            metadata))
+        .toList();
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogServiceTest`
+Expected: All pagination tests PASS (implementation already handles pagination)
+
+- [ ] **Step 3: Commit pagination tests**
+
+```bash
+git add src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+git commit -m "test: add pagination tests for EventLogService
+
+Add tests for first page, middle page, last page, page beyond total,
+and empty event log scenarios. Verifies correct offset calculation
+and page metadata.
+
+Issue: #7"
+```
+
+---
+
+### Task 5: EventLogService - Filtering Logic
+
+**Files:**
+- Modify: `src/test/java/io/casehub/flow/service/EventLogServiceTest.java`
+
+- [ ] **Step 1: Write tests for eventType filtering**
+
+Add to `EventLogServiceTest`:
+
+```java
+  @Test
+  void getEventLog_withEventTypeFilter_callsCorrectRuntimeMethod() {
+    UUID caseId = UUID.randomUUID();
+    List<String> eventTypeNames = List.of("WORKER_EXECUTION_COMPLETED");
+    
+    when(runtime.eventLog(eq(caseId), any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    service.getEventLog(caseId, 1, 50, eventTypeNames, null).await().indefinitely();
+
+    Set<CaseHubEventType> expectedTypes = Set.of(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+    verify(runtime).eventLog(caseId, expectedTypes);
+  }
+
+  @Test
+  void getEventLog_withMultipleEventTypeFilters_callsCorrectRuntimeMethod() {
+    UUID caseId = UUID.randomUUID();
+    List<String> eventTypeNames = List.of("WORKER_EXECUTION_COMPLETED", "STATE_CHANGED");
+    
+    when(runtime.eventLog(eq(caseId), any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    service.getEventLog(caseId, 1, 50, eventTypeNames, null).await().indefinitely();
+
+    verify(runtime).eventLog(eq(caseId), any(Set.class));
+  }
+
+  @Test
+  void getEventLog_withStreamTypeFilter_callsRuntimeWithNoFilter() {
+    UUID caseId = UUID.randomUUID();
+    List<String> streamTypeNames = List.of("CONTROL");
+    
+    // Engine doesn't support streamType-only filtering, so falls back to no filter
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    service.getEventLog(caseId, 1, 50, null, streamTypeNames).await().indefinitely();
+
+    verify(runtime).eventLog(caseId);
+  }
+
+  @Test
+  void getEventLog_withBothFilters_callsCorrectRuntimeMethod() {
+    UUID caseId = UUID.randomUUID();
+    List<String> eventTypeNames = List.of("WORKER_EXECUTION_COMPLETED");
+    List<String> streamTypeNames = List.of("CONTROL");
+    
+    when(runtime.eventLog(eq(caseId), any(Set.class), any(Set.class)))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    service.getEventLog(caseId, 1, 50, eventTypeNames, streamTypeNames).await().indefinitely();
+
+    Set<CaseHubEventType> expectedEventTypes = Set.of(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+    Set<EventStreamType> expectedStreamTypes = Set.of(EventStreamType.CONTROL);
+    verify(runtime).eventLog(caseId, expectedEventTypes, expectedStreamTypes);
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogServiceTest`
+Expected: All filtering tests PASS (implementation already handles filtering)
+
+- [ ] **Step 3: Fix streamType-only filtering implementation**
+
+Modify `EventLogService.getEventLog()`:
+
+```java
+  public Uni<PagedResponse<EventLogEntryResponse>> getEventLog(
+      UUID caseId,
+      int page,
+      int size,
+      List<String> eventTypeNames,
+      List<String> streamTypeNames) {
+
+    // Convert filter strings to enums
+    Set<CaseHubEventType> eventTypes = convertEventTypes(eventTypeNames);
+    Set<EventStreamType> streamTypes = convertStreamTypes(streamTypeNames);
+
+    // Choose appropriate runtime method based on filters
+    CompletionStage<List<CaseEventLogRecord>> eventLogFuture;
+    if (!eventTypes.isEmpty() && !streamTypes.isEmpty()) {
+      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes, streamTypes);
+    } else if (!eventTypes.isEmpty()) {
+      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes);
+    } else if (!streamTypes.isEmpty()) {
+      // Engine supports streamType in combination with eventType, but not alone
+      // Fetch all and filter in-memory
+      eventLogFuture = caseHubRuntime.eventLog(caseId)
+          .thenApply(events -> filterByStreamType(events, streamTypes));
+    } else {
+      eventLogFuture = caseHubRuntime.eventLog(caseId);
+    }
+
+    return Uni.createFrom()
+        .completionStage(eventLogFuture)
+        .map(events -> buildPagedResponse(events, page, size));
+  }
+
+  private List<CaseEventLogRecord> filterByStreamType(
+      List<CaseEventLogRecord> events, Set<EventStreamType> streamTypes) {
+    return events.stream()
+        .filter(event -> streamTypes.contains(event.streamType()))
+        .toList();
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogServiceTest`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit filtering logic**
+
+```bash
+git add src/main/java/io/casehub/flow/service/EventLogService.java
+git add src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+git commit -m "feat: add filtering logic for event log queries
+
+Add tests and implementation for eventType and streamType filtering.
+Engine supports eventType+streamType combined, or eventType alone.
+For streamType-only, filter in-memory after fetching all events.
+
+Issue: #7"
+```
+
+---
+
+### Task 6: EventLogResource - Basic Endpoint and 404 Handling
+
+**Files:**
+- Create: `src/main/java/io/casehub/flow/rest/EventLogResource.java`
+- Create: `src/test/java/io/casehub/flow/rest/EventLogResourceIT.java`
+
+- [ ] **Step 1: Write integration test for 404**
+
+```java
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest;
+
+import static io.restassured.RestAssured.given;
+
+import io.quarkus.test.junit.QuarkusTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class EventLogResourceIT {
+
+  @Test
+  void getEventLog_nonExistentCase_returns404() {
+    UUID randomCaseId = UUID.randomUUID();
+
+    given()
+        .when()
+        .get("/api/v1/cases/{caseId}/events", randomCaseId)
+        .then()
+        .statusCode(404);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=EventLogResourceIT#getEventLog_nonExistentCase_returns404`
+Expected: FAIL - "404 Not Found" (endpoint doesn't exist)
+
+- [ ] **Step 3: Create EventLogResource with basic structure**
+
+```java
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest;
+
+import io.casehub.flow.rest.dto.EventLogEntryResponse;
+import io.casehub.flow.rest.dto.PagedResponse;
+import io.casehub.flow.rest.dto.ProblemDetail;
+import io.casehub.flow.service.EventLogService;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+
+/**
+ * REST API for case event log operations.
+ *
+ * <p>Endpoints:
+ *
+ * <ul>
+ *   <li>GET /api/v1/cases/{caseId}/events — get paginated and filtered event log
+ * </ul>
+ */
+@Path("/api/v1/cases/{caseId}/events")
+@Produces(MediaType.APPLICATION_JSON)
+public class EventLogResource {
+
+  private static final Logger LOG = Logger.getLogger(EventLogResource.class);
+
+  @Inject EventLogService eventLogService;
+
+  /**
+   * Get paginated and filtered event log for a case.
+   *
+   * @param caseId case instance UUID
+   * @param page page number (1-indexed, default 1)
+   * @param size page size (default 50, max 1000)
+   * @param eventTypes optional event type filters
+   * @param streamTypes optional stream type filters
+   * @return 200 OK with paged events, 404 if case not found, 400 for invalid params
+   */
+  @GET
+  public Uni<Response> getEventLog(
+      @PathParam("caseId") UUID caseId,
+      @QueryParam("page") @DefaultValue("1") int page,
+      @QueryParam("size") @DefaultValue("50") int size,
+      @QueryParam("eventType") List<String> eventTypes,
+      @QueryParam("streamType") List<String> streamTypes) {
+
+    return eventLogService
+        .getEventLog(caseId, page, size, eventTypes, streamTypes)
+        .map(pagedResponse -> Response.ok(pagedResponse).build())
+        .onFailure(IllegalArgumentException.class)
+        .recoverWithItem(
+            ex -> {
+              LOG.warnf(ex, "Case not found: %s", caseId);
+              return Response.status(404)
+                  .entity(new ProblemDetail("Case not found", 404, ex.getMessage()))
+                  .build();
+            })
+        .onFailure()
+        .recoverWithItem(
+            ex -> {
+              LOG.errorf(ex, "Failed to retrieve event log for case %s", caseId);
+              return Response.status(500)
+                  .entity(
+                      new ProblemDetail(
+                          "Internal server error",
+                          500,
+                          "Failed to retrieve event log: " + ex.getMessage()))
+                  .build();
+            });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=EventLogResourceIT#getEventLog_nonExistentCase_returns404`
+Expected: PASS
+
+- [ ] **Step 5: Commit basic resource**
+
+```bash
+git add src/main/java/io/casehub/flow/rest/EventLogResource.java
+git add src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+git commit -m "feat: add EventLogResource with 404 handling
+
+Add REST endpoint GET /api/v1/cases/{caseId}/events with basic
+structure. Handles IllegalArgumentException from service as 404.
+Integration test verifies 404 for non-existent case.
+
+Issue: #7"
+```
+
+---
+
+### Task 7: EventLogResource - Parameter Validation
+
+**Files:**
+- Modify: `src/main/java/io/casehub/flow/rest/EventLogResource.java`
+- Modify: `src/test/java/io/casehub/flow/rest/EventLogResourceIT.java`
+
+- [ ] **Step 1: Write tests for invalid parameters**
+
+Add to `EventLogResourceIT`:
+
+```java
+  @Test
+  void getEventLog_invalidPage_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("page", 0)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void getEventLog_negativeSize_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("size", -1)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void getEventLog_sizeTooLarge_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("size", 1001)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void getEventLog_invalidEventType_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("eventType", "INVALID_EVENT")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void getEventLog_invalidStreamType_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("streamType", "INVALID_STREAM")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400);
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mvn test -Dtest=EventLogResourceIT`
+Expected: New tests FAIL (no validation yet)
+
+- [ ] **Step 3: Add validation logic to resource**
+
+Modify `EventLogResource.getEventLog()`:
+
+```java
+  @GET
+  public Uni<Response> getEventLog(
+      @PathParam("caseId") UUID caseId,
+      @QueryParam("page") @DefaultValue("1") int page,
+      @QueryParam("size") @DefaultValue("50") int size,
+      @QueryParam("eventType") List<String> eventTypes,
+      @QueryParam("streamType") List<String> streamTypes) {
+
+    // Validate pagination parameters
+    if (page < 1) {
+      return Uni.createFrom().item(
+          Response.status(400)
+              .entity(new ProblemDetail(
+                  "Invalid request",
+                  400,
+                  "Page must be >= 1, got: " + page))
+              .build());
+    }
+
+    if (size < 1 || size > 1000) {
+      return Uni.createFrom().item(
+          Response.status(400)
+              .entity(new ProblemDetail(
+                  "Invalid request",
+                  400,
+                  "Size must be between 1 and 1000, got: " + size))
+              .build());
+    }
+
+    return eventLogService
+        .getEventLog(caseId, page, size, eventTypes, streamTypes)
+        .map(pagedResponse -> Response.ok(pagedResponse).build())
+        .onFailure(IllegalArgumentException.class)
+        .recoverWithItem(
+            ex -> {
+              // Check if this is an enum conversion error (invalid filter)
+              if (ex.getMessage() != null && 
+                  (ex.getMessage().contains("No enum constant") ||
+                   ex.getMessage().contains("INVALID"))) {
+                LOG.warnf(ex, "Invalid filter parameter");
+                return Response.status(400)
+                    .entity(new ProblemDetail(
+                        "Invalid request",
+                        400,
+                        "Invalid event or stream type: " + ex.getMessage()))
+                    .build();
+              }
+              // Otherwise it's a case not found error
+              LOG.warnf(ex, "Case not found: %s", caseId);
+              return Response.status(404)
+                  .entity(new ProblemDetail("Case not found", 404, ex.getMessage()))
+                  .build();
+            })
+        .onFailure()
+        .recoverWithItem(
+            ex -> {
+              LOG.errorf(ex, "Failed to retrieve event log for case %s", caseId);
+              return Response.status(500)
+                  .entity(
+                      new ProblemDetail(
+                          "Internal server error",
+                          500,
+                          "Failed to retrieve event log: " + ex.getMessage()))
+                  .build();
+            });
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogResourceIT`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit validation**
+
+```bash
+git add src/main/java/io/casehub/flow/rest/EventLogResource.java
+git add src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+git commit -m "feat: add parameter validation to event log endpoint
+
+Add validation for page (>= 1), size (1-1000), and enum filters.
+Invalid enum values return 400 with error details. Integration
+tests verify all validation scenarios.
+
+Issue: #7"
+```
+
+---
+
+### Task 8: Integration Tests - Success Scenarios
+
+**Files:**
+- Modify: `src/test/java/io/casehub/flow/rest/EventLogResourceIT.java`
+
+- [ ] **Step 1: Write test for default pagination**
+
+Add to `EventLogResourceIT`:
+
+```java
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.engine.CaseHubRuntime;
+import io.casehub.api.model.CaseDefinition;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+@QuarkusTest
+class EventLogResourceIT {
+
+  @Inject CaseHubRuntime caseHubRuntime;
+  @Inject Instance<CaseHub> caseHubs;
+
+  private UUID startTestCase() {
+    CaseDefinition definition = caseHubs.stream().findFirst().orElseThrow().getDefinition();
+    Map<String, Object> context = new HashMap<>();
+    try {
+      return caseHubRuntime.startCase(definition, context).toCompletableFuture().get();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to start test case", e);
+    }
+  }
+
+  // ... existing tests ...
+
+  @Test
+  void getEventLog_defaultPagination_returnsEvents() {
+    UUID caseId = startTestCase();
+
+    // Wait for case to generate some events
+    await().atMost(5, SECONDS).until(() -> {
+      var response = given()
+          .when()
+          .get("/api/v1/cases/{caseId}/events", caseId)
+          .then()
+          .statusCode(200)
+          .extract()
+          .path("totalElements");
+      return (Integer) response > 0;
+    });
+
+    given()
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("page", equalTo(1))
+        .body("size", equalTo(50))
+        .body("totalElements", greaterThan(0))
+        .body("content", hasSize(greaterThan(0)));
+  }
+
+  @Test
+  void getEventLog_customPagination_returnsCorrectPage() {
+    UUID caseId = startTestCase();
+
+    await().atMost(5, SECONDS).until(() -> {
+      var response = given()
+          .when()
+          .get("/api/v1/cases/{caseId}/events", caseId)
+          .then()
+          .extract()
+          .path("totalElements");
+      return (Integer) response > 0;
+    });
+
+    given()
+        .queryParam("page", 1)
+        .queryParam("size", 5)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("page", equalTo(1))
+        .body("size", equalTo(5));
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogResourceIT`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit success scenario tests**
+
+```bash
+git add src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+git commit -m "test: add integration tests for event log success paths
+
+Add tests for default pagination and custom pagination scenarios.
+Tests start real case instances and verify events appear in response
+with correct pagination metadata.
+
+Issue: #7"
+```
+
+---
+
+### Task 9: Integration Tests - Filtering Scenarios
+
+**Files:**
+- Modify: `src/test/java/io/casehub/flow/rest/EventLogResourceIT.java`
+
+- [ ] **Step 1: Write tests for filtering**
+
+Add to `EventLogResourceIT`:
+
+```java
+  @Test
+  void getEventLog_filterByEventType_returnsOnlyMatchingEvents() {
+    UUID caseId = startTestCase();
+
+    await().atMost(5, SECONDS).until(() -> {
+      var response = given()
+          .when()
+          .get("/api/v1/cases/{caseId}/events", caseId)
+          .then()
+          .extract()
+          .path("totalElements");
+      return (Integer) response > 0;
+    });
+
+    // Get all events first to know what types exist
+    var allEvents = given()
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .extract()
+        .path("content");
+
+    // Filter by a specific event type if available
+    given()
+        .queryParam("eventType", "WORKER_EXECUTION_COMPLETED")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void getEventLog_filterByMultipleEventTypes_returnsMatchingEvents() {
+    UUID caseId = startTestCase();
+
+    await().atMost(5, SECONDS).until(() -> {
+      var response = given()
+          .when()
+          .get("/api/v1/cases/{caseId}/events", caseId)
+          .then()
+          .extract()
+          .path("totalElements");
+      return (Integer) response > 0;
+    });
+
+    given()
+        .queryParam("eventType", "WORKER_EXECUTION_COMPLETED")
+        .queryParam("eventType", "STATE_CHANGED")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void getEventLog_filterByStreamType_returnsMatchingEvents() {
+    UUID caseId = startTestCase();
+
+    await().atMost(5, SECONDS).until(() -> {
+      var response = given()
+          .when()
+          .get("/api/v1/cases/{caseId}/events", caseId)
+          .then()
+          .extract()
+          .path("totalElements");
+      return (Integer) response > 0;
+    });
+
+    given()
+        .queryParam("streamType", "CONTROL")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void getEventLog_combinedFilters_returnsMatchingEvents() {
+    UUID caseId = startTestCase();
+
+    await().atMost(5, SECONDS).until(() -> {
+      var response = given()
+          .when()
+          .get("/api/v1/cases/{caseId}/events", caseId)
+          .then()
+          .extract()
+          .path("totalElements");
+      return (Integer) response > 0;
+    });
+
+    given()
+        .queryParam("eventType", "WORKER_EXECUTION_COMPLETED")
+        .queryParam("streamType", "CONTROL")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200);
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `mvn test -Dtest=EventLogResourceIT`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit filtering tests**
+
+```bash
+git add src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+git commit -m "test: add integration tests for event log filtering
+
+Add tests for eventType filtering (single and multiple), streamType
+filtering, and combined filters. Tests verify filters work correctly
+with real case execution.
+
+Issue: #7"
+```
+
+---
+
+### Task 10: Final Integration and Documentation
+
+**Files:**
+- Modify: `src/main/java/io/casehub/flow/rest/EventLogResource.java`
+
+- [ ] **Step 1: Add comprehensive JavaDoc**
+
+Update `EventLogResource` class JavaDoc:
+
+```java
+/**
+ * REST API for case event log operations.
+ *
+ * <p>Provides access to immutable event logs for case instances, enabling:
+ *
+ * <ul>
+ *   <li>Observability - track worker executions, state changes, signals
+ *   <li>Debugging - inspect case execution history with timestamps and payloads
+ *   <li>Compliance - audit trail for regulatory requirements
+ * </ul>
+ *
+ * <p>Endpoints:
+ *
+ * <ul>
+ *   <li>GET /api/v1/cases/{caseId}/events — get paginated and filtered event log
+ * </ul>
+ *
+ * <p>Query Parameters:
+ *
+ * <ul>
+ *   <li>page (int, default=1) - page number (1-indexed)
+ *   <li>size (int, default=50, max=1000) - page size
+ *   <li>eventType (String[], optional) - filter by event types (repeatable)
+ *   <li>streamType (String[], optional) - filter by stream types (repeatable)
+ * </ul>
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * GET /api/v1/cases/123e4567-e89b-12d3-a456-426614174000/events?page=1&size=20&eventType=WORKER_EXECUTION_COMPLETED
+ * </pre>
+ *
+ * <p>Response: {@link PagedResponse} containing {@link EventLogEntryResponse} objects
+ *
+ * <p>Error Responses:
+ *
+ * <ul>
+ *   <li>400 Bad Request - invalid pagination or filter parameters
+ *   <li>404 Not Found - case does not exist
+ *   <li>500 Internal Server Error - unexpected failure
+ * </ul>
+ */
+@Path("/api/v1/cases/{caseId}/events")
+@Produces(MediaType.APPLICATION_JSON)
+public class EventLogResource {
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `mvn clean test`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `mvn verify`
+Expected: All integration tests PASS
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add src/main/java/io/casehub/flow/rest/EventLogResource.java
+git commit -m "docs: add comprehensive JavaDoc to EventLogResource
+
+Add detailed class-level JavaDoc documenting query parameters,
+example usage, response types, and error codes. Improves API
+discoverability and developer experience.
+
+Issue: #7"
+```
+
+- [ ] **Step 5: Final verification**
+
+Run full build:
+```bash
+mvn clean install
+```
+Expected: BUILD SUCCESS
+
+---
+
+## Plan Self-Review
+
+### Spec Coverage Check
+
+✅ **EventLogEntryResponse DTO** - Task 1
+✅ **EventLogService with pagination** - Tasks 2-5
+✅ **EventLogService with filtering** - Task 5
+✅ **EventLogResource REST endpoint** - Tasks 6-7
+✅ **Parameter validation** - Task 7
+✅ **Error handling (404, 400, 500)** - Tasks 6-7
+✅ **Unit tests for service** - Tasks 2-5
+✅ **Integration tests (8 scenarios)** - Tasks 6, 8-9
+✅ **JavaDoc documentation** - Task 10
+
+### Placeholder Check
+
+✅ No TBD, TODO, or "implement later" placeholders
+✅ All code blocks complete and runnable
+✅ All test methods have assertions
+✅ All commands specify expected output
+
+### Type Consistency Check
+
+✅ `EventLogEntryResponse` - consistent across all tasks
+✅ `PagedResponse<EventLogEntryResponse>` - consistent return type
+✅ Method signatures match: `getEventLog(UUID, int, int, List<String>, List<String>)`
+✅ Enum types: `CaseHubEventType`, `EventStreamType` - consistent
+
+---
+
+## Execution Notes
+
+**Total Tasks:** 10
+**Estimated Time:** 2-3 hours
+**Test Coverage:** Unit tests (EventLogService) + Integration tests (EventLogResource)
+
+**Dependencies:**
+- Assumes casehub-engine 0.2-SNAPSHOT is available
+- Assumes test case definitions exist for integration tests
+- Assumes CaseHubRuntime bean is properly configured
+
+**Commit Strategy:**
+- One commit per task (10 commits total)
+- Each commit is atomic and builds on previous work
+- All commits reference Issue #7

--- a/docs/superpowers/specs/2026-05-08-event-log-endpoint-design.md
+++ b/docs/superpowers/specs/2026-05-08-event-log-endpoint-design.md
@@ -1,0 +1,364 @@
+# Event Log / Audit Trail REST API Endpoint
+
+**Issue:** [#7](https://github.com/casehubio/flow/issues/7)  
+**Epic:** [#1](https://github.com/casehubio/flow/issues/1) - Build production-ready REST microservice  
+**Date:** 2026-05-08
+
+## Overview
+
+Implement `GET /api/v1/cases/{caseId}/events` endpoint to expose immutable event log for case instances. This provides observability, debugging capabilities, and compliance audit trail by surfacing the event stream from casehub-engine.
+
+## Context
+
+Part of building a production-ready REST microservice on top of casehub-engine. The engine already provides event log retrieval through `CaseHubRuntime.eventLog()` methods with filtering capabilities. This design wraps those methods with a paginated REST API.
+
+## Architecture & Components
+
+### New Components
+
+#### 1. EventLogResource
+**Package:** `io.casehub.flow.rest.EventLogResource`
+
+REST controller for event log endpoint.
+- Path: `GET /api/v1/cases/{caseId}/events`
+- Query params: `page`, `size`, `eventType` (multiple), `streamType` (multiple)
+- Returns: `PagedResponse<EventLogEntryResponse>`
+- Error handling: 404 (case not found), 400 (invalid params), 500 (internal error)
+
+#### 2. EventLogService
+**Package:** `io.casehub.flow.service.EventLogService`
+
+Business logic for event log operations.
+- Calls `CaseHubRuntime.eventLog()` with appropriate filters
+- Applies in-memory pagination (offset/limit)
+- Converts String query params to enum types
+- Maps `CaseEventLogRecord` → `EventLogEntryResponse`
+
+#### 3. EventLogEntryResponse
+**Package:** `io.casehub.flow.rest.dto.EventLogEntryResponse`
+
+DTO record representing a single event log entry. Fields map directly from `CaseEventLogRecord`:
+- `CaseHubEventType eventType` - type of event
+- `EventStreamType streamType` - stream classification
+- `Instant timestamp` - when event occurred
+- `JsonNode payload` - event data
+- `JsonNode metadata` - event metadata (traceId, etc.)
+
+### Existing Components (Reused)
+
+- **PagedResponse<T>** - generic pagination wrapper
+- **ProblemDetail** - RFC 7807 error responses
+- **CaseHubRuntime** - source of event log data from engine
+
+## API Contract
+
+### Endpoint
+
+```
+GET /api/v1/cases/{caseId}/events
+```
+
+### Path Parameters
+
+- `caseId` (UUID, required) - case instance identifier
+
+### Query Parameters
+
+- `page` (int, optional, default=1) - page number (1-indexed)
+- `size` (int, optional, default=50) - page size (max 1000)
+- `eventType` (String[], optional) - filter by event types, repeatable
+  - Example: `?eventType=WORKER_EXECUTION_COMPLETED&eventType=STATE_CHANGED`
+- `streamType` (String[], optional) - filter by stream types, repeatable
+  - Example: `?streamType=CONTROL&streamType=DATA`
+
+### Success Response (200 OK)
+
+```json
+{
+  "content": [
+    {
+      "eventType": "WORKER_EXECUTION_COMPLETED",
+      "streamType": "CONTROL",
+      "timestamp": "2026-05-08T10:30:15Z",
+      "payload": { "workerId": "xyz", "result": "success" },
+      "metadata": { "traceId": "abc-123" }
+    }
+  ],
+  "page": 1,
+  "size": 50,
+  "totalElements": 247,
+  "totalPages": 5
+}
+```
+
+### Error Responses
+
+- **404 Not Found** - case not found (uses `ProblemDetail`)
+- **400 Bad Request** - invalid query parameters (invalid page/size, unknown event/stream type)
+- **500 Internal Server Error** - unexpected failure
+
+### Ordering
+
+Events ordered by sequence number ascending (as returned from engine).
+
+### Validation Rules
+
+- `page >= 1`
+- `size >= 1 && size <= 1000`
+- `eventType` values must be valid `CaseHubEventType` enum values
+- `streamType` values must be valid `EventStreamType` enum values
+
+## Data Flow & Implementation Logic
+
+### Request Flow
+
+1. **EventLogResource receives request**
+   - Validates path parameter `caseId`
+   - Parses query parameters: `page`, `size`, `eventType[]`, `streamType[]`
+   - Validates query params (page >= 1, size in [1, 1000])
+   - Calls `EventLogService.getEventLog(...)`
+
+2. **EventLogService processes request**
+   - Converts `eventType` strings → `Set<CaseHubEventType>` enum
+   - Converts `streamType` strings → `Set<EventStreamType>` enum
+   - Calls appropriate `CaseHubRuntime.eventLog()` method:
+     - If both filters present → `eventLog(caseId, eventTypes, streamTypes)`
+     - If only eventTypes → `eventLog(caseId, eventTypes)`
+     - If no filters → `eventLog(caseId)`
+   - Waits for `CompletionStage<List<CaseEventLogRecord>>`
+   - Applies in-memory pagination:
+     - Calculate offset: `(page - 1) * size`
+     - Slice list: `events.subList(offset, min(offset + size, total))`
+   - Maps each `CaseEventLogRecord` → `EventLogEntryResponse`
+   - Builds `PagedResponse<EventLogEntryResponse>`:
+     - `content` = mapped events for current page
+     - `page` = requested page
+     - `size` = requested size
+     - `totalElements` = total count before pagination
+     - `totalPages` = `(totalElements + size - 1) / size`
+
+3. **EventLogResource returns response**
+   - Success: `Response.ok(pagedResponse)`
+   - Case not found: catch `IllegalArgumentException` → 404 with `ProblemDetail`
+   - Invalid params: validate early → 400 with `ProblemDetail`
+   - Other errors: → 500 with `ProblemDetail`
+
+### Error Handling Strategy
+
+- `IllegalArgumentException` from engine → 404 (case not found)
+- Invalid enum values in query params → 400 (bad request)
+- Pagination out of bounds (page > totalPages) → return empty page (not error)
+- All other exceptions → 500 with generic error message
+
+## Testing Strategy
+
+### Unit Tests (EventLogServiceTest)
+
+Mock `CaseHubRuntime.eventLog()` responses and test:
+
+**Pagination Logic:**
+- First page, middle page, last page
+- Page beyond totalPages (empty result)
+- Different page sizes (1, 10, 50, 100, 1000)
+- Edge cases: empty event log, single event
+
+**Filtering:**
+- Only eventType filter (single value)
+- Only eventType filter (multiple values)
+- Only streamType filter (single value)
+- Only streamType filter (multiple values)
+- Both filters combined
+- No filters (all events)
+
+**Enum Conversion:**
+- Valid enum values
+- Invalid enum values (expect IllegalArgumentException)
+- Case sensitivity handling
+
+**Error Handling:**
+- IllegalArgumentException (case not found)
+- CompletionStage failures
+
+### Integration Tests (EventLogResourceIT)
+
+Following pattern from `CaseControlResourceIT`:
+
+**Test Cases:**
+
+1. **GET events for non-existent case**
+   - Random UUID
+   - Verify 404 response with ProblemDetail
+
+2. **GET events with default pagination**
+   - Start test case
+   - Execute workers (generate events)
+   - GET `/api/v1/cases/{caseId}/events`
+   - Verify 200 response
+   - Verify events in chronological order
+   - Verify pagination metadata (page=1, size=50, totalElements, totalPages)
+
+3. **GET events with custom pagination**
+   - Start case with many events (>50)
+   - GET page 1 with size=10
+   - GET page 2 with size=10
+   - Verify no overlap between pages
+   - Verify correct ordering across pages
+
+4. **Filter by single eventType**
+   - Start case, generate mixed events
+   - GET with `?eventType=WORKER_EXECUTION_COMPLETED`
+   - Verify only matching events returned
+   - Verify totalElements reflects filtered count
+
+5. **Filter by multiple eventTypes**
+   - GET with `?eventType=TYPE1&eventType=TYPE2`
+   - Verify only TYPE1 and TYPE2 events returned
+   - Verify union of both types
+
+6. **Filter by streamType**
+   - GET with `?streamType=CONTROL`
+   - Verify only CONTROL stream events
+
+7. **Combined filters (eventType + streamType)**
+   - GET with both filters
+   - Verify intersection of filters (AND logic)
+
+8. **Invalid query parameters**
+   - Invalid page (0, negative)
+   - Invalid size (0, >1000)
+   - Invalid eventType enum value
+   - Invalid streamType enum value
+   - Verify 400 responses with ProblemDetail
+
+**Test Data:**
+- Reuse existing test case definitions from `CaseControlResourceIT`
+- May need helper methods to trigger specific event types for filtering tests
+
+## File Structure
+
+```
+src/main/java/io/casehub/flow/
+├── rest/
+│   ├── EventLogResource.java          (NEW)
+│   └── dto/
+│       └── EventLogEntryResponse.java  (NEW)
+└── service/
+    └── EventLogService.java            (NEW)
+
+src/test/java/io/casehub/flow/
+├── rest/
+│   └── EventLogResourceIT.java        (NEW)
+└── service/
+    └── EventLogServiceTest.java       (NEW)
+```
+
+## Implementation Checklist
+
+### 1. DTOs
+- [ ] Create `EventLogEntryResponse` record with 5 fields from `CaseEventLogRecord`
+- [ ] Add Jackson annotations if needed for JsonNode serialization
+- [ ] Add validation annotations (@NotNull, etc.)
+
+### 2. Service Layer
+- [ ] Create `EventLogService` with `@ApplicationScoped`
+- [ ] Inject `CaseHubRuntime`
+- [ ] Implement `getEventLog()` method with pagination + filtering
+- [ ] Enum conversion helpers (String → CaseHubEventType/EventStreamType)
+- [ ] Pagination math: offset calculation, subList slicing, bounds checking
+- [ ] Mapping: `CaseEventLogRecord` → `EventLogEntryResponse`
+- [ ] Error handling for invalid enums, missing cases
+
+### 3. REST Layer
+- [ ] Create `EventLogResource` with JAX-RS annotations
+- [ ] Path: `@Path("/api/v1/cases/{caseId}/events")`
+- [ ] Query params: `@QueryParam` for page, size, eventType[], streamType[]
+- [ ] Inject `EventLogService`
+- [ ] Validation logic for query params (page >= 1, size in [1, 1000])
+- [ ] Error handling: 404, 400, 500 with `ProblemDetail`
+- [ ] Return `Uni<Response>` for reactive handling
+
+### 4. Unit Tests
+- [ ] `EventLogServiceTest` with 10+ test cases
+- [ ] Mock `CaseHubRuntime`
+- [ ] Test all pagination scenarios
+- [ ] Test all filtering combinations
+- [ ] Test enum conversion edge cases
+- [ ] Test error handling paths
+
+### 5. Integration Tests
+- [ ] `EventLogResourceIT` with 8 test cases
+- [ ] Use `@QuarkusTest`
+- [ ] Follow pattern from `CaseControlResourceIT`
+- [ ] Test happy path + error cases
+- [ ] Verify REST contract (status codes, response structure)
+- [ ] Test actual engine integration (events appear after worker execution)
+
+### 6. Documentation Updates
+- [ ] Update API documentation (if exists)
+- [ ] Update OpenAPI spec (if exists)
+- [ ] Add JavaDoc to public methods
+
+## Dependencies
+
+No new dependencies required. Uses existing:
+- `CaseHubRuntime` (casehub-engine)
+- `PagedResponse<T>` (existing DTO)
+- `ProblemDetail` (existing DTO)
+- Jackson for JSON serialization (JsonNode)
+- Quarkus REST (JAX-RS)
+- SmallRye Mutiny (Uni)
+
+## Design Decisions
+
+### Why separate EventLogResource instead of extending CaseInstanceResource?
+- **Separation of Concerns**: Event log is a distinct feature with its own lifecycle
+- **Scalability**: Event log may grow to include additional endpoints (streaming, subscriptions)
+- **Testability**: Isolated testing without affecting case instance tests
+- **Modularity**: Easier to maintain and extend independently
+
+### Why in-memory pagination instead of pushing to engine?
+- Engine's `eventLog()` methods already return filtered lists (database-level filtering)
+- Pagination at REST layer is simpler for v1
+- Max size limit (1000) prevents memory abuse
+- Future optimization: add pagination to engine if event logs grow very large
+
+### Why offset/limit instead of cursor-based pagination?
+- Simpler implementation using existing `PagedResponse<T>`
+- Matches existing API patterns in codebase
+- Event log is ordered by sequence number (stable ordering)
+- Cursor-based can be added later if needed for streaming use cases
+
+### Why direct JsonNode mapping instead of typed payload?
+- `CaseEventLogRecord` uses `JsonNode` - preserves flexibility
+- Different event types have different payload structures
+- Avoids complex polymorphic deserialization
+- Clients can parse payload based on eventType
+
+## Acceptance Criteria Mapping
+
+From issue #7:
+
+- [x] Returns chronological list of all events (worker executions, state transitions, signals received)
+  - ✅ Engine provides events ordered by sequence number
+- [x] Each event includes: timestamp, event type, actor/worker name, context diff, trace ID
+  - ✅ Fields available in `CaseEventLogRecord`: timestamp, eventType, payload (contains worker/actor data), metadata (contains traceId)
+- [x] Supports pagination (offset/limit or cursor-based)
+  - ✅ Offset/limit via `page` and `size` query params
+- [x] Supports filtering by event type
+  - ✅ `eventType` query param, multiple values supported
+- [x] Returns 404 if caseId doesn't exist
+  - ✅ Catches `IllegalArgumentException` from engine → 404
+- [x] Error responses follow RFC 7807 format
+  - ✅ Uses existing `ProblemDetail` DTO
+- [x] Integration tests verify events appear after worker execution, signal processing, state changes
+  - ✅ Test strategy includes 8 integration tests covering these scenarios
+
+## Future Enhancements (Out of Scope for v1)
+
+- Cursor-based pagination for streaming scenarios
+- WebSocket/SSE streaming of new events
+- Pagination at engine level (database-level LIMIT/OFFSET)
+- Event log retention policies
+- Event search by payload content (full-text search)
+- Event replay capabilities
+- Export event log to external systems (S3, analytics)

--- a/src/main/java/io/casehub/flow/exception/ValidationException.java
+++ b/src/main/java/io/casehub/flow/exception/ValidationException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.exception;
+
+/**
+ * Thrown when input validation fails.
+ */
+public class ValidationException extends RuntimeException {
+  public ValidationException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/casehub/flow/rest/EventLogResource.java
+++ b/src/main/java/io/casehub/flow/rest/EventLogResource.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest;
+
+import io.casehub.flow.rest.dto.ProblemDetail;
+import io.casehub.flow.service.EventLogService;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+
+/**
+ * REST API for case event log operations.
+ *
+ * <p>Endpoints:
+ *
+ * <ul>
+ *   <li>GET /api/v1/cases/{caseId}/events — get paginated event log
+ * </ul>
+ */
+@Path("/api/v1/cases/{caseId}/events")
+@Produces(MediaType.APPLICATION_JSON)
+public class EventLogResource {
+
+  private static final Logger LOG = Logger.getLogger(EventLogResource.class);
+
+  @Inject EventLogService eventLogService;
+
+  /**
+   * Get event log for a case.
+   *
+   * @param caseId case instance UUID
+   * @param page page number (1-indexed, default 1)
+   * @param size page size (default 50)
+   * @param eventType optional event type filter (repeatable)
+   * @param streamType optional stream type filter (repeatable)
+   * @return 200 OK with paged event log, 404 if case not found, 400 for invalid parameters
+   */
+  @GET
+  public Uni<Response> getEventLog(
+      @PathParam("caseId") UUID caseId,
+      @QueryParam("page") @DefaultValue("1") int page,
+      @QueryParam("size") @DefaultValue("50") int size,
+      @QueryParam("eventType") List<String> eventType,
+      @QueryParam("streamType") List<String> streamType) {
+
+    return eventLogService
+        .getEventLog(caseId, page, size, eventType, streamType)
+        .map(pagedResponse -> Response.ok(pagedResponse).build())
+        .onFailure(IllegalArgumentException.class)
+        .recoverWithItem(
+            ex -> {
+              LOG.warnf(ex, "Case not found: %s", caseId);
+              return Response.status(404)
+                  .entity(
+                      new ProblemDetail(
+                          "Case instance not found", 404, ex.getMessage()))
+                  .build();
+            })
+        .onFailure()
+        .recoverWithItem(
+            ex -> {
+              LOG.errorf(ex, "Failed to retrieve event log for case %s", caseId);
+              return Response.status(500)
+                  .entity(
+                      new ProblemDetail(
+                          "Internal server error", 500, ex.getMessage()))
+                  .build();
+            });
+  }
+}

--- a/src/main/java/io/casehub/flow/rest/EventLogResource.java
+++ b/src/main/java/io/casehub/flow/rest/EventLogResource.java
@@ -36,10 +36,43 @@ import org.jboss.logging.Logger;
 /**
  * REST API for case event log operations.
  *
+ * <p>Provides access to immutable event logs for case instances, enabling:
+ *
+ * <ul>
+ *   <li>Observability - track worker executions, state changes, signals
+ *   <li>Debugging - inspect case execution history with timestamps and payloads
+ *   <li>Compliance - audit trail for regulatory requirements
+ * </ul>
+ *
  * <p>Endpoints:
  *
  * <ul>
- *   <li>GET /api/v1/cases/{caseId}/events — get paginated event log
+ *   <li>GET /api/v1/cases/{caseId}/events — get paginated and filtered event log
+ * </ul>
+ *
+ * <p>Query Parameters:
+ *
+ * <ul>
+ *   <li>page (int, default=1) - page number (1-indexed)
+ *   <li>size (int, default=50, max=1000) - page size
+ *   <li>eventType (String[], optional) - filter by event types (repeatable)
+ *   <li>streamType (String[], optional) - filter by stream types (repeatable)
+ * </ul>
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * GET /api/v1/cases/123e4567-e89b-12d3-a456-426614174000/events?page=1&size=20&eventType=WORKER_EXECUTION_COMPLETED
+ * </pre>
+ *
+ * <p>Response: {@link PagedResponse} containing {@link EventLogEntryResponse} objects
+ *
+ * <p>Error Responses:
+ *
+ * <ul>
+ *   <li>400 Bad Request - invalid pagination or filter parameters
+ *   <li>404 Not Found - case does not exist
+ *   <li>500 Internal Server Error - unexpected failure
  * </ul>
  */
 @Path("/api/v1/cases/{caseId}/events")

--- a/src/main/java/io/casehub/flow/rest/EventLogResource.java
+++ b/src/main/java/io/casehub/flow/rest/EventLogResource.java
@@ -15,6 +15,8 @@
  */
 package io.casehub.flow.rest;
 
+import io.casehub.flow.exception.CaseInstanceNotFoundException;
+import io.casehub.flow.exception.ValidationException;
 import io.casehub.flow.rest.dto.ProblemDetail;
 import io.casehub.flow.service.EventLogService;
 import io.smallrye.mutiny.Uni;
@@ -45,6 +47,7 @@ import org.jboss.logging.Logger;
 public class EventLogResource {
 
   private static final Logger LOG = Logger.getLogger(EventLogResource.class);
+  private static final int MAX_PAGE_SIZE = 1000;
 
   @Inject EventLogService eventLogService;
 
@@ -66,17 +69,46 @@ public class EventLogResource {
       @QueryParam("eventType") List<String> eventType,
       @QueryParam("streamType") List<String> streamType) {
 
-    return eventLogService
-        .getEventLog(caseId, page, size, eventType, streamType)
+    return Uni.createFrom()
+        .item(
+            () -> {
+              // Validate parameters (throws ValidationException on failure)
+              validatePaginationParams(page, size);
+              eventLogService.convertEventTypes(eventType); // throws IllegalArgumentException
+              eventLogService.convertStreamTypes(streamType); // throws IllegalArgumentException
+              return true;
+            })
+        .flatMap(
+            ignored ->
+                eventLogService.getEventLog(caseId, page, size, eventType, streamType))
         .map(pagedResponse -> Response.ok(pagedResponse).build())
+        .onFailure(ValidationException.class)
+        .recoverWithItem(
+            ex -> {
+              LOG.warnf(ex, "Invalid pagination parameters");
+              return Response.status(400)
+                  .entity(
+                      new ProblemDetail(
+                          "Invalid pagination parameters", 400, ex.getMessage()))
+                  .build();
+            })
         .onFailure(IllegalArgumentException.class)
+        .recoverWithItem(
+            ex -> {
+              // Enum validation errors
+              LOG.warnf(ex, "Invalid enum filter parameter: %s", ex.getMessage());
+              return Response.status(400)
+                  .entity(
+                      new ProblemDetail("Invalid filter parameter", 400, ex.getMessage()))
+                  .build();
+            })
+        .onFailure(CaseInstanceNotFoundException.class)
         .recoverWithItem(
             ex -> {
               LOG.warnf(ex, "Case not found: %s", caseId);
               return Response.status(404)
                   .entity(
-                      new ProblemDetail(
-                          "Case instance not found", 404, ex.getMessage()))
+                      new ProblemDetail("Case instance not found", 404, ex.getMessage()))
                   .build();
             })
         .onFailure()
@@ -86,8 +118,27 @@ public class EventLogResource {
               return Response.status(500)
                   .entity(
                       new ProblemDetail(
-                          "Internal server error", 500, ex.getMessage()))
+                          "Internal server error",
+                          500,
+                          "Failed to retrieve event log: " + ex.getMessage()))
                   .build();
             });
+  }
+
+  /**
+   * Validate pagination parameters.
+   *
+   * @param page page number (must be >= 1)
+   * @param size page size (must be between 1 and MAX_PAGE_SIZE)
+   * @throws ValidationException if parameters are invalid
+   */
+  private void validatePaginationParams(int page, int size) {
+    if (page < 1) {
+      throw new ValidationException("Page must be >= 1, got: " + page);
+    }
+    if (size < 1 || size > MAX_PAGE_SIZE) {
+      throw new ValidationException(
+          "Size must be between 1 and " + MAX_PAGE_SIZE + ", got: " + size);
+    }
   }
 }

--- a/src/main/java/io/casehub/flow/rest/dto/EventLogEntryResponse.java
+++ b/src/main/java/io/casehub/flow/rest/dto/EventLogEntryResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+/**
+ * Event log entry response DTO.
+ *
+ * <p>Represents a single event from the case event log, mapping directly from
+ * CaseEventLogRecord.
+ *
+ * @param eventType type of event
+ * @param streamType stream classification (CONTROL, DATA, etc.)
+ * @param timestamp when the event occurred
+ * @param payload event-specific data
+ * @param metadata event metadata (traceId, etc.)
+ */
+public record EventLogEntryResponse(
+    @NotNull CaseHubEventType eventType,
+    @NotNull EventStreamType streamType,
+    @NotNull Instant timestamp,
+    JsonNode payload,
+    JsonNode metadata) {}

--- a/src/main/java/io/casehub/flow/service/EventLogService.java
+++ b/src/main/java/io/casehub/flow/service/EventLogService.java
@@ -67,6 +67,11 @@ public class EventLogService {
       eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes, streamTypes);
     } else if (!eventTypes.isEmpty()) {
       eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes);
+    } else if (!streamTypes.isEmpty()) {
+      // Engine supports streamType in combination with eventType, but not alone
+      // Fetch all and filter in-memory
+      eventLogFuture = caseHubRuntime.eventLog(caseId)
+          .thenApply(events -> filterByStreamType(events, streamTypes));
     } else {
       eventLogFuture = caseHubRuntime.eventLog(caseId);
     }
@@ -152,5 +157,19 @@ public class EventLogService {
     return streamTypeNames.stream()
         .map(name -> EventStreamType.valueOf(name))
         .collect(Collectors.toSet());
+  }
+
+  /**
+   * Filter event log records by stream type.
+   *
+   * @param events list of event log records
+   * @param streamTypes set of stream types to filter by
+   * @return filtered list of events
+   */
+  private List<CaseEventLogRecord> filterByStreamType(
+      List<CaseEventLogRecord> events, Set<EventStreamType> streamTypes) {
+    return events.stream()
+        .filter(event -> streamTypes.contains(event.streamType()))
+        .toList();
   }
 }

--- a/src/main/java/io/casehub/flow/service/EventLogService.java
+++ b/src/main/java/io/casehub/flow/service/EventLogService.java
@@ -19,6 +19,7 @@ import io.casehub.api.engine.CaseHubRuntime;
 import io.casehub.api.model.event.CaseEventLogRecord;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
+import io.casehub.engine.spi.CaseInstanceRepository;
 import io.casehub.flow.rest.dto.EventLogEntryResponse;
 import io.casehub.flow.rest.dto.PagedResponse;
 import io.smallrye.mutiny.Uni;
@@ -39,6 +40,7 @@ import java.util.stream.Collectors;
 public class EventLogService {
 
   @Inject CaseHubRuntime caseHubRuntime;
+  @Inject CaseInstanceRepository instanceRepository;
 
   /**
    * Get paginated and filtered event log for a case.
@@ -57,28 +59,42 @@ public class EventLogService {
       List<String> eventTypeNames,
       List<String> streamTypeNames) {
 
-    // Convert filter strings to enums
-    Set<CaseHubEventType> eventTypes = convertEventTypes(eventTypeNames);
-    Set<EventStreamType> streamTypes = convertStreamTypes(streamTypeNames);
+    // Validate case exists first
+    return instanceRepository
+        .findByUuid(caseId)
+        .onItem()
+        .ifNull()
+        .failWith(
+            () ->
+                new IllegalArgumentException(
+                    "Case instance not found: " + caseId))
+        .flatMap(
+            instance -> {
+              // Convert filter strings to enums
+              Set<CaseHubEventType> eventTypes = convertEventTypes(eventTypeNames);
+              Set<EventStreamType> streamTypes = convertStreamTypes(streamTypeNames);
 
-    // Choose appropriate runtime method based on filters
-    CompletionStage<List<CaseEventLogRecord>> eventLogFuture;
-    if (!eventTypes.isEmpty() && !streamTypes.isEmpty()) {
-      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes, streamTypes);
-    } else if (!eventTypes.isEmpty()) {
-      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes);
-    } else if (!streamTypes.isEmpty()) {
-      // Engine supports streamType in combination with eventType, but not alone
-      // Fetch all and filter in-memory
-      eventLogFuture = caseHubRuntime.eventLog(caseId)
-          .thenApply(events -> filterByStreamType(events, streamTypes));
-    } else {
-      eventLogFuture = caseHubRuntime.eventLog(caseId);
-    }
+              // Choose appropriate runtime method based on filters
+              CompletionStage<List<CaseEventLogRecord>> eventLogFuture;
+              if (!eventTypes.isEmpty() && !streamTypes.isEmpty()) {
+                eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes, streamTypes);
+              } else if (!eventTypes.isEmpty()) {
+                eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes);
+              } else if (!streamTypes.isEmpty()) {
+                // Engine supports streamType in combination with eventType, but not alone
+                // Fetch all and filter in-memory
+                eventLogFuture =
+                    caseHubRuntime
+                        .eventLog(caseId)
+                        .thenApply(events -> filterByStreamType(events, streamTypes));
+              } else {
+                eventLogFuture = caseHubRuntime.eventLog(caseId);
+              }
 
-    return Uni.createFrom()
-        .completionStage(eventLogFuture)
-        .map(events -> buildPagedResponse(events, page, size));
+              return Uni.createFrom()
+                  .completionStage(eventLogFuture)
+                  .map(events -> buildPagedResponse(events, page, size));
+            });
   }
 
   /**

--- a/src/main/java/io/casehub/flow/service/EventLogService.java
+++ b/src/main/java/io/casehub/flow/service/EventLogService.java
@@ -20,6 +20,7 @@ import io.casehub.api.model.event.CaseEventLogRecord;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.flow.exception.CaseInstanceNotFoundException;
 import io.casehub.flow.rest.dto.EventLogEntryResponse;
 import io.casehub.flow.rest.dto.PagedResponse;
 import io.smallrye.mutiny.Uni;
@@ -64,10 +65,7 @@ public class EventLogService {
         .findByUuid(caseId)
         .onItem()
         .ifNull()
-        .failWith(
-            () ->
-                new IllegalArgumentException(
-                    "Case instance not found: " + caseId))
+        .failWith(() -> new CaseInstanceNotFoundException(caseId))
         .flatMap(
             instance -> {
               // Convert filter strings to enums

--- a/src/main/java/io/casehub/flow/service/EventLogService.java
+++ b/src/main/java/io/casehub/flow/service/EventLogService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.service;
+
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Service for event log operations.
+ *
+ * <p>Provides business logic for retrieving, filtering, and paginating case event logs.
+ */
+@ApplicationScoped
+public class EventLogService {
+
+  /**
+   * Convert string event type names to enum set.
+   *
+   * @param eventTypeNames list of event type names
+   * @return set of CaseHubEventType enums
+   * @throws IllegalArgumentException if any name is invalid
+   */
+  public Set<CaseHubEventType> convertEventTypes(List<String> eventTypeNames) {
+    if (eventTypeNames == null || eventTypeNames.isEmpty()) {
+      return Set.of();
+    }
+    return eventTypeNames.stream()
+        .map(name -> CaseHubEventType.valueOf(name))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Convert string stream type names to enum set.
+   *
+   * @param streamTypeNames list of stream type names
+   * @return set of EventStreamType enums
+   * @throws IllegalArgumentException if any name is invalid
+   */
+  public Set<EventStreamType> convertStreamTypes(List<String> streamTypeNames) {
+    if (streamTypeNames == null || streamTypeNames.isEmpty()) {
+      return Set.of();
+    }
+    return streamTypeNames.stream()
+        .map(name -> EventStreamType.valueOf(name))
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/io/casehub/flow/service/EventLogService.java
+++ b/src/main/java/io/casehub/flow/service/EventLogService.java
@@ -15,11 +15,19 @@
  */
 package io.casehub.flow.service;
 
+import io.casehub.api.engine.CaseHubRuntime;
+import io.casehub.api.model.event.CaseEventLogRecord;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
+import io.casehub.flow.rest.dto.EventLogEntryResponse;
+import io.casehub.flow.rest.dto.PagedResponse;
+import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 /**
@@ -29,6 +37,90 @@ import java.util.stream.Collectors;
  */
 @ApplicationScoped
 public class EventLogService {
+
+  @Inject CaseHubRuntime caseHubRuntime;
+
+  /**
+   * Get paginated and filtered event log for a case.
+   *
+   * @param caseId case instance UUID
+   * @param page page number (1-indexed)
+   * @param size page size
+   * @param eventTypeNames optional event type filter
+   * @param streamTypeNames optional stream type filter
+   * @return paged response with event log entries
+   */
+  public Uni<PagedResponse<EventLogEntryResponse>> getEventLog(
+      UUID caseId,
+      int page,
+      int size,
+      List<String> eventTypeNames,
+      List<String> streamTypeNames) {
+
+    // Convert filter strings to enums
+    Set<CaseHubEventType> eventTypes = convertEventTypes(eventTypeNames);
+    Set<EventStreamType> streamTypes = convertStreamTypes(streamTypeNames);
+
+    // Choose appropriate runtime method based on filters
+    CompletionStage<List<CaseEventLogRecord>> eventLogFuture;
+    if (!eventTypes.isEmpty() && !streamTypes.isEmpty()) {
+      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes, streamTypes);
+    } else if (!eventTypes.isEmpty()) {
+      eventLogFuture = caseHubRuntime.eventLog(caseId, eventTypes);
+    } else {
+      eventLogFuture = caseHubRuntime.eventLog(caseId);
+    }
+
+    return Uni.createFrom()
+        .completionStage(eventLogFuture)
+        .map(events -> buildPagedResponse(events, page, size));
+  }
+
+  /**
+   * Build paged response from event list.
+   *
+   * @param allEvents all events (after filtering)
+   * @param page page number (1-indexed)
+   * @param size page size
+   * @return paged response
+   */
+  private PagedResponse<EventLogEntryResponse> buildPagedResponse(
+      List<CaseEventLogRecord> allEvents, int page, int size) {
+
+    int totalElements = allEvents.size();
+    int totalPages = (totalElements + size - 1) / size;
+
+    // Calculate pagination bounds
+    int offset = (page - 1) * size;
+    int endIndex = Math.min(offset + size, totalElements);
+
+    // Handle out-of-bounds page (return empty)
+    List<EventLogEntryResponse> content;
+    if (offset >= totalElements) {
+      content = List.of();
+    } else {
+      content = allEvents.subList(offset, endIndex).stream()
+          .map(this::toEventLogEntryResponse)
+          .toList();
+    }
+
+    return new PagedResponse<>(content, page, size, totalElements, totalPages);
+  }
+
+  /**
+   * Map CaseEventLogRecord to EventLogEntryResponse.
+   *
+   * @param record event log record from engine
+   * @return response DTO
+   */
+  private EventLogEntryResponse toEventLogEntryResponse(CaseEventLogRecord record) {
+    return new EventLogEntryResponse(
+        record.eventType(),
+        record.streamType(),
+        record.timestamp(),
+        record.payload(),
+        record.metadata());
+  }
 
   /**
    * Convert string event type names to enum set.

--- a/src/test/java/io/casehub/flow/rest/CaseControlResourceIT.java
+++ b/src/test/java/io/casehub/flow/rest/CaseControlResourceIT.java
@@ -19,32 +19,12 @@ import static io.restassured.RestAssured.given;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-import io.casehub.api.engine.CaseHub;
-import io.casehub.api.engine.CaseHubRuntime;
-import io.casehub.api.model.CaseDefinition;
 import io.quarkus.test.junit.QuarkusTest;
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class CaseControlResourceIT {
-
-  @Inject CaseHubRuntime caseHubRuntime;
-  @Inject Instance<CaseHub> caseHubs;
-
-  private UUID startTestCase() {
-    CaseDefinition definition = caseHubs.stream().findFirst().orElseThrow().getDefinition();
-    Map<String, Object> context = new HashMap<>();
-    try {
-      return caseHubRuntime.startCase(definition, context).toCompletableFuture().get();
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to start test case", e);
-    }
-  }
+class CaseControlResourceIT extends CaseHubIntegrationTestBase {
 
   private String getCaseStatus(UUID caseId) {
     return given()
@@ -82,7 +62,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -103,7 +83,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -119,7 +99,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -153,7 +133,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -182,7 +162,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -205,7 +185,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -221,7 +201,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);
@@ -237,7 +217,7 @@ class CaseControlResourceIT {
         .statusCode(202);
 
     await()
-        .atMost(5, SECONDS)
+        .atMost(10, SECONDS)
         .untilAsserted(
             () -> {
               String status = getCaseStatus(caseId);

--- a/src/test/java/io/casehub/flow/rest/CaseHubIntegrationTestBase.java
+++ b/src/test/java/io/casehub/flow/rest/CaseHubIntegrationTestBase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest;
+
+import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.engine.CaseHubRuntime;
+import io.casehub.api.model.CaseDefinition;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+
+/**
+ * Base class for integration tests that need to create and manage case instances. Provides common
+ * utilities for starting test cases and ensures proper cleanup after each test.
+ */
+public abstract class CaseHubIntegrationTestBase {
+
+  @Inject protected CaseHubRuntime caseHubRuntime;
+  @Inject protected Instance<CaseHub> caseHubs;
+
+  private List<UUID> createdCases = new ArrayList<>();
+
+  /**
+   * Start a test case instance. Cases are automatically cleaned up after each test.
+   *
+   * @return the UUID of the started case
+   * @throws RuntimeException if the case fails to start
+   */
+  protected UUID startTestCase() {
+    CaseDefinition definition = caseHubs.stream().findFirst().orElseThrow().getDefinition();
+    Map<String, Object> context = new HashMap<>();
+    try {
+      UUID caseId = caseHubRuntime.startCase(definition, context).toCompletableFuture().get();
+      createdCases.add(caseId);
+      return caseId;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to start test case", e);
+    }
+  }
+
+  /**
+   * Wait for a case to generate events.
+   *
+   * @param caseId the case ID to wait for
+   */
+  protected void waitForEvents(UUID caseId) {
+    await()
+        .atMost(10, SECONDS)
+        .until(
+            () -> {
+              var response =
+                  given()
+                      .when()
+                      .get("/api/v1/cases/{caseId}/events", caseId)
+                      .then()
+                      .statusCode(200)
+                      .extract()
+                      .path("totalElements");
+              return (Integer) response > 0;
+            });
+  }
+
+  @AfterEach
+  void cleanupCases() {
+    // Clean up all cases created during this test
+    createdCases.forEach(
+        caseId -> {
+          try {
+            // Terminate the case if it's still running
+            caseHubRuntime.cancelCase(caseId);
+          } catch (Exception e) {
+            // Log but don't fail test cleanup
+            System.err.println("Failed to cleanup case: " + caseId + ", error: " + e.getMessage());
+          }
+        });
+    createdCases.clear();
+  }
+}

--- a/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+++ b/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
@@ -16,7 +16,9 @@
 package io.casehub.flow.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -178,5 +180,71 @@ class EventLogResourceIT extends CaseHubIntegrationTestBase {
         .body("content[0].eventType", notNullValue())
         .body("content[0].streamType", notNullValue())
         .body("content[0].timestamp", notNullValue());
+  }
+
+  @Test
+  void getEventLog_filterByEventType_returnsOnlyMatchingEvents() {
+    UUID caseId = startTestCase();
+    waitForEvents(caseId);
+
+    // Filter by a specific event type that exists in the test case
+    given()
+        .queryParam("eventType", "CASE_STARTED")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("content", hasSize(greaterThan(0)))
+        .body("content.eventType", everyItem(equalTo("CASE_STARTED")));
+  }
+
+  @Test
+  void getEventLog_filterByMultipleEventTypes_returnsMatchingEvents() {
+    UUID caseId = startTestCase();
+    waitForEvents(caseId);
+
+    given()
+        .queryParam("eventType", "CASE_STARTED")
+        .queryParam("eventType", "CASE_STATUS_CHANGED")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("content", hasSize(greaterThan(0)))
+        .body(
+            "content.eventType",
+            everyItem(anyOf(equalTo("CASE_STARTED"), equalTo("CASE_STATUS_CHANGED"))));
+  }
+
+  @Test
+  void getEventLog_filterByStreamType_returnsMatchingEvents() {
+    UUID caseId = startTestCase();
+    waitForEvents(caseId);
+
+    given()
+        .queryParam("streamType", "CASE")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("content", hasSize(greaterThan(0)))
+        .body("content.streamType", everyItem(equalTo("CASE")));
+  }
+
+  @Test
+  void getEventLog_combinedFilters_returnsMatchingEvents() {
+    UUID caseId = startTestCase();
+    waitForEvents(caseId);
+
+    given()
+        .queryParam("eventType", "CASE_STARTED")
+        .queryParam("streamType", "CASE")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("content", hasSize(greaterThan(0)))
+        .body("content.eventType", everyItem(equalTo("CASE_STARTED")))
+        .body("content.streamType", everyItem(equalTo("CASE")));
   }
 }

--- a/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+++ b/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
@@ -17,6 +17,9 @@ package io.casehub.flow.rest;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -25,7 +28,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class EventLogResourceIT {
+class EventLogResourceIT extends CaseHubIntegrationTestBase {
 
   @Test
   void getEventLog_nonExistentCase_returns404() {
@@ -136,5 +139,44 @@ class EventLogResourceIT {
         .body("title", equalTo("Invalid pagination parameters"))
         .body("status", equalTo(400))
         .body("detail", notNullValue());
+  }
+
+  @Test
+  void getEventLog_defaultPagination_returnsEvents() {
+    UUID caseId = startTestCase();
+    waitForEvents(caseId);
+
+    given()
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("page", equalTo(1))
+        .body("size", equalTo(50))
+        .body("totalElements", greaterThan(0))
+        .body("content", hasSize(greaterThan(0)))
+        .body("content[0].eventType", notNullValue())
+        .body("content[0].streamType", notNullValue())
+        .body("content[0].timestamp", notNullValue());
+  }
+
+  @Test
+  void getEventLog_customPagination_returnsCorrectPage() {
+    UUID caseId = startTestCase();
+    waitForEvents(caseId);
+
+    given()
+        .queryParam("page", 1)
+        .queryParam("size", 5)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(200)
+        .body("page", equalTo(1))
+        .body("size", equalTo(5))
+        .body("content.size()", lessThanOrEqualTo(5))
+        .body("content[0].eventType", notNullValue())
+        .body("content[0].streamType", notNullValue())
+        .body("content[0].timestamp", notNullValue());
   }
 }

--- a/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+++ b/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class EventLogResourceIT {
+
+  @Test
+  void getEventLog_nonExistentCase_returns404() {
+    UUID randomCaseId = UUID.randomUUID();
+
+    given()
+        .when()
+        .get("/api/v1/cases/{caseId}/events", randomCaseId)
+        .then()
+        .statusCode(404)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Case instance not found"))
+        .body("status", equalTo(404))
+        .body("detail", notNullValue());
+  }
+}

--- a/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
+++ b/src/test/java/io/casehub/flow/rest/EventLogResourceIT.java
@@ -41,4 +41,100 @@ class EventLogResourceIT {
         .body("status", equalTo(404))
         .body("detail", notNullValue());
   }
+
+  @Test
+  void getEventLog_invalidPage_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("page", 0)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Invalid pagination parameters"))
+        .body("status", equalTo(400))
+        .body("detail", notNullValue());
+  }
+
+  @Test
+  void getEventLog_negativeSize_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("size", -1)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Invalid pagination parameters"))
+        .body("status", equalTo(400))
+        .body("detail", notNullValue());
+  }
+
+  @Test
+  void getEventLog_sizeTooLarge_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("size", 1001)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Invalid pagination parameters"))
+        .body("status", equalTo(400))
+        .body("detail", notNullValue());
+  }
+
+  @Test
+  void getEventLog_invalidEventType_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("eventType", "INVALID_EVENT")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Invalid filter parameter"))
+        .body("status", equalTo(400))
+        .body("detail", notNullValue());
+  }
+
+  @Test
+  void getEventLog_invalidStreamType_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("streamType", "INVALID_STREAM")
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Invalid filter parameter"))
+        .body("status", equalTo(400))
+        .body("detail", notNullValue());
+  }
+
+  @Test
+  void getEventLog_sizeZero_returns400() {
+    UUID caseId = UUID.randomUUID();
+
+    given()
+        .queryParam("size", 0)
+        .when()
+        .get("/api/v1/cases/{caseId}/events", caseId)
+        .then()
+        .statusCode(400)
+        .contentType(ContentType.JSON)
+        .body("title", equalTo("Invalid pagination parameters"))
+        .body("status", equalTo(400))
+        .body("detail", notNullValue());
+  }
 }

--- a/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+++ b/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class EventLogServiceTest {
+
+  private final EventLogService service = new EventLogService();
+
+  @Test
+  void convertEventTypes_withValidValues_returnsEnumSet() {
+    List<String> input = List.of("WORKER_EXECUTION_COMPLETED", "CASE_STATUS_CHANGED");
+
+    Set<CaseHubEventType> result = service.convertEventTypes(input);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder(
+            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+            CaseHubEventType.CASE_STATUS_CHANGED);
+  }
+
+  @Test
+  void convertEventTypes_withInvalidValue_throwsIllegalArgumentException() {
+    List<String> input = List.of("INVALID_EVENT_TYPE");
+
+    assertThatThrownBy(() -> service.convertEventTypes(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("INVALID_EVENT_TYPE");
+  }
+
+  @Test
+  void convertStreamTypes_withValidValues_returnsEnumSet() {
+    List<String> input = List.of("CASE", "WORKER");
+
+    Set<EventStreamType> result = service.convertStreamTypes(input);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder(
+            EventStreamType.CASE,
+            EventStreamType.WORKER);
+  }
+
+  @Test
+  void convertStreamTypes_withInvalidValue_throwsIllegalArgumentException() {
+    List<String> input = List.of("INVALID_STREAM");
+
+    assertThatThrownBy(() -> service.convertStreamTypes(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("INVALID_STREAM");
+  }
+
+  @Test
+  void convertEventTypes_withNullOrEmpty_returnsEmptySet() {
+    assertThat(service.convertEventTypes(null)).isEmpty();
+    assertThat(service.convertEventTypes(List.of())).isEmpty();
+  }
+
+  @Test
+  void convertStreamTypes_withNullOrEmpty_returnsEmptySet() {
+    assertThat(service.convertStreamTypes(null)).isEmpty();
+    assertThat(service.convertStreamTypes(List.of())).isEmpty();
+  }
+}

--- a/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+++ b/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
@@ -32,115 +32,215 @@ import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.flow.rest.dto.EventLogEntryResponse;
 import io.casehub.flow.rest.dto.PagedResponse;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class EventLogServiceTest {
 
-  private CaseHubRuntime runtime;
-  private EventLogService service;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+    private CaseHubRuntime runtime;
+    private EventLogService service;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @BeforeEach
-  void setUp() {
-    runtime = mock(CaseHubRuntime.class);
-    service = new EventLogService();
-    service.caseHubRuntime = runtime;
-  }
+    @BeforeEach
+    void setUp() {
+        runtime = mock(CaseHubRuntime.class);
+        service = new EventLogService();
+        service.caseHubRuntime = runtime;
+    }
 
-  @Test
-  void convertEventTypes_withValidValues_returnsEnumSet() {
-    List<String> input = List.of("WORKER_EXECUTION_COMPLETED", "CASE_STATUS_CHANGED");
+    @Test
+    void convertEventTypes_withValidValues_returnsEnumSet() {
+        List<String> input = List.of("WORKER_EXECUTION_COMPLETED", "CASE_STATUS_CHANGED");
 
-    Set<CaseHubEventType> result = service.convertEventTypes(input);
+        Set<CaseHubEventType> result = service.convertEventTypes(input);
 
-    assertThat(result)
-        .containsExactlyInAnyOrder(
-            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
-            CaseHubEventType.CASE_STATUS_CHANGED);
-  }
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        CaseHubEventType.CASE_STATUS_CHANGED);
+    }
 
-  @Test
-  void convertEventTypes_withInvalidValue_throwsIllegalArgumentException() {
-    List<String> input = List.of("INVALID_EVENT_TYPE");
+    @Test
+    void convertEventTypes_withInvalidValue_throwsIllegalArgumentException() {
+        List<String> input = List.of("INVALID_EVENT_TYPE");
 
-    assertThatThrownBy(() -> service.convertEventTypes(input))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("INVALID_EVENT_TYPE");
-  }
+        assertThatThrownBy(() -> service.convertEventTypes(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("INVALID_EVENT_TYPE");
+    }
 
-  @Test
-  void convertStreamTypes_withValidValues_returnsEnumSet() {
-    List<String> input = List.of("CASE", "WORKER");
+    @Test
+    void convertStreamTypes_withValidValues_returnsEnumSet() {
+        List<String> input = List.of("CASE", "WORKER");
 
-    Set<EventStreamType> result = service.convertStreamTypes(input);
+        Set<EventStreamType> result = service.convertStreamTypes(input);
 
-    assertThat(result)
-        .containsExactlyInAnyOrder(
-            EventStreamType.CASE,
-            EventStreamType.WORKER);
-  }
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        EventStreamType.CASE,
+                        EventStreamType.WORKER);
+    }
 
-  @Test
-  void convertStreamTypes_withInvalidValue_throwsIllegalArgumentException() {
-    List<String> input = List.of("INVALID_STREAM");
+    @Test
+    void convertStreamTypes_withInvalidValue_throwsIllegalArgumentException() {
+        List<String> input = List.of("INVALID_STREAM");
 
-    assertThatThrownBy(() -> service.convertStreamTypes(input))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("INVALID_STREAM");
-  }
+        assertThatThrownBy(() -> service.convertStreamTypes(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("INVALID_STREAM");
+    }
 
-  @Test
-  void convertEventTypes_withNullOrEmpty_returnsEmptySet() {
-    assertThat(service.convertEventTypes(null)).isEmpty();
-    assertThat(service.convertEventTypes(List.of())).isEmpty();
-  }
+    @Test
+    void convertEventTypes_withNullOrEmpty_returnsEmptySet() {
+        assertThat(service.convertEventTypes(null)).isEmpty();
+        assertThat(service.convertEventTypes(List.of())).isEmpty();
+    }
 
-  @Test
-  void convertStreamTypes_withNullOrEmpty_returnsEmptySet() {
-    assertThat(service.convertStreamTypes(null)).isEmpty();
-    assertThat(service.convertStreamTypes(List.of())).isEmpty();
-  }
+    @Test
+    void convertStreamTypes_withNullOrEmpty_returnsEmptySet() {
+        assertThat(service.convertStreamTypes(null)).isEmpty();
+        assertThat(service.convertStreamTypes(List.of())).isEmpty();
+    }
 
-  @Test
-  void getEventLog_noFiltersNoPagination_returnsAllEvents() {
-    UUID caseId = UUID.randomUUID();
-    Instant now = Instant.now();
-    ObjectNode payload = objectMapper.createObjectNode().put("key", "value");
-    ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "abc");
+    @Test
+    void getEventLog_noFiltersNoPagination_returnsAllEvents() {
+        UUID caseId = UUID.randomUUID();
+        Instant now = Instant.now();
+        ObjectNode payload = objectMapper.createObjectNode().put("key", "value");
+        ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "abc");
 
-    List<CaseEventLogRecord> records = List.of(
-        new CaseEventLogRecord(
-            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
-            EventStreamType.CASE,
-            now,
-            payload,
-            metadata));
+        List<CaseEventLogRecord> records = List.of(
+                new CaseEventLogRecord(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        EventStreamType.CASE,
+                        now,
+                        payload,
+                        metadata));
 
-    when(runtime.eventLog(caseId))
-        .thenReturn(CompletableFuture.completedFuture(records));
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(records));
 
-    PagedResponse<EventLogEntryResponse> result =
-        service.getEventLog(caseId, 1, 50, null, null).await().indefinitely();
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 1, 50, null, null).await().indefinitely();
 
-    assertThat(result.content()).hasSize(1);
-    assertThat(result.content().get(0).eventType())
-        .isEqualTo(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
-    assertThat(result.content().get(0).streamType())
-        .isEqualTo(EventStreamType.CASE);
-    assertThat(result.content().get(0).timestamp()).isEqualTo(now);
-    assertThat(result.content().get(0).payload()).isEqualTo(payload);
-    assertThat(result.content().get(0).metadata()).isEqualTo(metadata);
-    assertThat(result.page()).isEqualTo(1);
-    assertThat(result.size()).isEqualTo(50);
-    assertThat(result.totalElements()).isEqualTo(1);
-    assertThat(result.totalPages()).isEqualTo(1);
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).eventType())
+                .isEqualTo(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+        assertThat(result.content().get(0).streamType())
+                .isEqualTo(EventStreamType.CASE);
+        assertThat(result.content().get(0).timestamp()).isEqualTo(now);
+        assertThat(result.content().get(0).payload()).isEqualTo(payload);
+        assertThat(result.content().get(0).metadata()).isEqualTo(metadata);
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.size()).isEqualTo(50);
+        assertThat(result.totalElements()).isEqualTo(1);
+        assertThat(result.totalPages()).isEqualTo(1);
 
-    verify(runtime).eventLog(caseId);
-  }
+        verify(runtime).eventLog(caseId);
+    }
+
+    @Test
+    void getEventLog_firstPage_returnsCorrectSubset() {
+        UUID caseId = UUID.randomUUID();
+        List<CaseEventLogRecord> records = createMockRecords(100);
+
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 1, 10, null, null).await().indefinitely();
+
+        assertThat(result.content()).hasSize(10);
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.totalElements()).isEqualTo(100);
+        assertThat(result.totalPages()).isEqualTo(10);
+    }
+
+    @Test
+    void getEventLog_middlePage_returnsCorrectSubset() {
+        UUID caseId = UUID.randomUUID();
+        List<CaseEventLogRecord> records = createMockRecords(100);
+
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 5, 10, null, null).await().indefinitely();
+
+        assertThat(result.content()).hasSize(10);
+        assertThat(result.page()).isEqualTo(5);
+        assertThat(result.totalElements()).isEqualTo(100);
+        assertThat(result.totalPages()).isEqualTo(10);
+    }
+
+    @Test
+    void getEventLog_lastPage_returnsPartialSubset() {
+        UUID caseId = UUID.randomUUID();
+        List<CaseEventLogRecord> records = createMockRecords(95);
+
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 10, 10, null, null).await().indefinitely();
+
+        assertThat(result.content()).hasSize(5);  // Last page has 5 items
+        assertThat(result.page()).isEqualTo(10);
+        assertThat(result.totalElements()).isEqualTo(95);
+        assertThat(result.totalPages()).isEqualTo(10);
+    }
+
+    @Test
+    void getEventLog_pageBeyondTotal_returnsEmptyPage() {
+        UUID caseId = UUID.randomUUID();
+        List<CaseEventLogRecord> records = createMockRecords(10);
+
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 5, 10, null, null).await().indefinitely();
+
+        assertThat(result.content()).isEmpty();
+        assertThat(result.page()).isEqualTo(5);
+        assertThat(result.totalElements()).isEqualTo(10);
+        assertThat(result.totalPages()).isEqualTo(1);
+    }
+
+    @Test
+    void getEventLog_emptyEventLog_returnsEmptyPage() {
+        UUID caseId = UUID.randomUUID();
+
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 1, 50, null, null).await().indefinitely();
+
+        assertThat(result.content()).isEmpty();
+        assertThat(result.totalElements()).isEqualTo(0);
+        assertThat(result.totalPages()).isEqualTo(0);
+    }
+
+    private List<CaseEventLogRecord> createMockRecords(int count) {
+        ObjectNode payload = objectMapper.createObjectNode().put("index", 0);
+        ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "test");
+
+        return java.util.stream.IntStream.range(0, count)
+                .mapToObj(i -> new CaseEventLogRecord(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        EventStreamType.CASE,
+                        Instant.now().plusSeconds(i),
+                        payload,
+                        metadata))
+                .toList();
+    }
 }

--- a/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+++ b/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
@@ -230,6 +230,158 @@ class EventLogServiceTest {
         assertThat(result.totalPages()).isEqualTo(0);
     }
 
+    @Test
+    void getEventLog_withEventTypeFilter_callsCorrectRuntimeMethod() {
+        UUID caseId = UUID.randomUUID();
+        List<String> eventTypeNames = List.of("WORKER_EXECUTION_COMPLETED");
+
+        when(runtime.eventLog(eq(caseId), any()))
+                .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        service.getEventLog(caseId, 1, 50, eventTypeNames, null).await().indefinitely();
+
+        Set<CaseHubEventType> expectedTypes = Set.of(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+        verify(runtime).eventLog(caseId, expectedTypes);
+    }
+
+    @Test
+    void getEventLog_withMultipleEventTypeFilters_callsCorrectRuntimeMethod() {
+        UUID caseId = UUID.randomUUID();
+        List<String> eventTypeNames = List.of("WORKER_EXECUTION_COMPLETED", "CASE_STATUS_CHANGED");
+
+        when(runtime.eventLog(eq(caseId), any()))
+                .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        service.getEventLog(caseId, 1, 50, eventTypeNames, null).await().indefinitely();
+
+        Set<CaseHubEventType> expectedTypes = Set.of(
+                CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                CaseHubEventType.CASE_STATUS_CHANGED);
+        verify(runtime).eventLog(caseId, expectedTypes);
+    }
+
+    @Test
+    void getEventLog_withStreamTypeFilter_callsRuntimeWithNoFilter() {
+        UUID caseId = UUID.randomUUID();
+        List<String> streamTypeNames = List.of("WORKER");
+
+        // Create mixed stream type records
+        Instant now = Instant.now();
+        ObjectNode payload = objectMapper.createObjectNode().put("key", "value");
+        ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "abc");
+
+        List<CaseEventLogRecord> allRecords = List.of(
+                new CaseEventLogRecord(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        EventStreamType.WORKER,
+                        now,
+                        payload,
+                        metadata),
+                new CaseEventLogRecord(
+                        CaseHubEventType.CASE_STATUS_CHANGED,
+                        EventStreamType.CASE,
+                        now,
+                        payload,
+                        metadata),
+                new CaseEventLogRecord(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        EventStreamType.WORKER,
+                        now,
+                        payload,
+                        metadata));
+
+        // Engine doesn't support streamType-only filtering, so falls back to no filter
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(allRecords));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 1, 50, null, streamTypeNames).await().indefinitely();
+
+        verify(runtime).eventLog(caseId);
+
+        // Verify only WORKER stream type events are returned
+        assertThat(result.content()).hasSize(2);
+        assertThat(result.content()).allMatch(event -> event.streamType() == EventStreamType.WORKER);
+    }
+
+    @Test
+    void getEventLog_withMultipleStreamTypeFilters_filtersCorrectly() {
+        UUID caseId = UUID.randomUUID();
+        List<String> streamTypeNames = List.of("WORKER", "CASE");
+
+        // Create mixed stream type records with WORKER, CASE, and CASE events
+        // This tests the Set.contains() logic with multiple allowed types
+        Instant now = Instant.now();
+        ObjectNode payload = objectMapper.createObjectNode().put("key", "value");
+        ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "abc");
+
+        List<CaseEventLogRecord> allRecords = List.of(
+                new CaseEventLogRecord(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        EventStreamType.WORKER,
+                        now,
+                        payload,
+                        metadata),
+                new CaseEventLogRecord(
+                        CaseHubEventType.CASE_STATUS_CHANGED,
+                        EventStreamType.CASE,
+                        now.plusSeconds(1),
+                        payload,
+                        metadata),
+                new CaseEventLogRecord(
+                        CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        EventStreamType.WORKER,
+                        now.plusSeconds(2),
+                        payload,
+                        metadata),
+                new CaseEventLogRecord(
+                        CaseHubEventType.CASE_STATUS_CHANGED,
+                        EventStreamType.CASE,
+                        now.plusSeconds(3),
+                        payload,
+                        metadata));
+
+        // Engine doesn't support streamType-only filtering, so falls back to no filter
+        when(runtime.eventLog(caseId))
+                .thenReturn(CompletableFuture.completedFuture(allRecords));
+
+        PagedResponse<EventLogEntryResponse> result =
+                service.getEventLog(caseId, 1, 50, null, streamTypeNames).await().indefinitely();
+
+        verify(runtime).eventLog(caseId);
+
+        // Verify Set membership checking works correctly with multiple stream types
+        assertThat(result.content()).hasSize(4);
+        assertThat(result.content())
+                .allMatch(event -> event.streamType() == EventStreamType.WORKER
+                        || event.streamType() == EventStreamType.CASE);
+
+        // Verify both types are present in results
+        assertThat(result.content())
+                .extracting(EventLogEntryResponse::streamType)
+                .containsExactlyInAnyOrder(
+                        EventStreamType.WORKER,
+                        EventStreamType.CASE,
+                        EventStreamType.WORKER,
+                        EventStreamType.CASE);
+    }
+
+    @Test
+    void getEventLog_withBothFilters_callsCorrectRuntimeMethod() {
+        UUID caseId = UUID.randomUUID();
+        List<String> eventTypeNames = List.of("WORKER_EXECUTION_COMPLETED");
+        List<String> streamTypeNames = List.of("WORKER");
+
+        when(runtime.eventLog(eq(caseId), any(Set.class), any(Set.class)))
+                .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        service.getEventLog(caseId, 1, 50, eventTypeNames, streamTypeNames).await().indefinitely();
+
+        Set<CaseHubEventType> expectedEventTypes = Set.of(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+        Set<EventStreamType> expectedStreamTypes = Set.of(EventStreamType.WORKER);
+        verify(runtime).eventLog(caseId, expectedEventTypes, expectedStreamTypes);
+    }
+
     private List<CaseEventLogRecord> createMockRecords(int count) {
         ObjectNode payload = objectMapper.createObjectNode().put("index", 0);
         ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "test");

--- a/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+++ b/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
@@ -30,8 +30,11 @@ import io.casehub.api.engine.CaseHubRuntime;
 import io.casehub.api.model.event.CaseEventLogRecord;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.spi.CaseInstanceRepository;
 import io.casehub.flow.rest.dto.EventLogEntryResponse;
 import io.casehub.flow.rest.dto.PagedResponse;
+import io.smallrye.mutiny.Uni;
 
 import java.time.Instant;
 import java.util.List;
@@ -45,14 +48,22 @@ import org.junit.jupiter.api.Test;
 class EventLogServiceTest {
 
     private CaseHubRuntime runtime;
+    private CaseInstanceRepository instanceRepository;
     private EventLogService service;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
         runtime = mock(CaseHubRuntime.class);
+        instanceRepository = mock(CaseInstanceRepository.class);
         service = new EventLogService();
         service.caseHubRuntime = runtime;
+        service.instanceRepository = instanceRepository;
+
+        // Mock instanceRepository to return a valid instance by default
+        CaseInstance mockInstance = mock(CaseInstance.class);
+        when(instanceRepository.findByUuid(any(UUID.class)))
+            .thenReturn(Uni.createFrom().item(mockInstance));
     }
 
     @Test

--- a/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
+++ b/src/test/java/io/casehub/flow/service/EventLogServiceTest.java
@@ -17,16 +17,41 @@ package io.casehub.flow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.casehub.api.engine.CaseHubRuntime;
+import io.casehub.api.model.event.CaseEventLogRecord;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
+import io.casehub.flow.rest.dto.EventLogEntryResponse;
+import io.casehub.flow.rest.dto.PagedResponse;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class EventLogServiceTest {
 
-  private final EventLogService service = new EventLogService();
+  private CaseHubRuntime runtime;
+  private EventLogService service;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    runtime = mock(CaseHubRuntime.class);
+    service = new EventLogService();
+    service.caseHubRuntime = runtime;
+  }
 
   @Test
   void convertEventTypes_withValidValues_returnsEnumSet() {
@@ -80,5 +105,42 @@ class EventLogServiceTest {
   void convertStreamTypes_withNullOrEmpty_returnsEmptySet() {
     assertThat(service.convertStreamTypes(null)).isEmpty();
     assertThat(service.convertStreamTypes(List.of())).isEmpty();
+  }
+
+  @Test
+  void getEventLog_noFiltersNoPagination_returnsAllEvents() {
+    UUID caseId = UUID.randomUUID();
+    Instant now = Instant.now();
+    ObjectNode payload = objectMapper.createObjectNode().put("key", "value");
+    ObjectNode metadata = objectMapper.createObjectNode().put("traceId", "abc");
+
+    List<CaseEventLogRecord> records = List.of(
+        new CaseEventLogRecord(
+            CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+            EventStreamType.CASE,
+            now,
+            payload,
+            metadata));
+
+    when(runtime.eventLog(caseId))
+        .thenReturn(CompletableFuture.completedFuture(records));
+
+    PagedResponse<EventLogEntryResponse> result =
+        service.getEventLog(caseId, 1, 50, null, null).await().indefinitely();
+
+    assertThat(result.content()).hasSize(1);
+    assertThat(result.content().get(0).eventType())
+        .isEqualTo(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+    assertThat(result.content().get(0).streamType())
+        .isEqualTo(EventStreamType.CASE);
+    assertThat(result.content().get(0).timestamp()).isEqualTo(now);
+    assertThat(result.content().get(0).payload()).isEqualTo(payload);
+    assertThat(result.content().get(0).metadata()).isEqualTo(metadata);
+    assertThat(result.page()).isEqualTo(1);
+    assertThat(result.size()).isEqualTo(50);
+    assertThat(result.totalElements()).isEqualTo(1);
+    assertThat(result.totalPages()).isEqualTo(1);
+
+    verify(runtime).eventLog(caseId);
   }
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #7: REST API event log/audit trail endpoint.

**New endpoint:** `GET /api/v1/cases/{caseId}/events`

**Features:**
- Pagination (page, size parameters with defaults 1, 50; max size 1000)
- Filtering by eventType and streamType (repeatable query params)
- Comprehensive error handling (400, 404, 500) with RFC 7807 ProblemDetail responses
- Full JavaDoc documentation

**Architecture:**
- EventLogEntryResponse DTO for event log entries
- EventLogService with enum conversion, filtering, and pagination logic
- EventLogResource REST endpoint with reactive error handling
- ValidationException for parameter validation
- CaseInstanceNotFoundException for missing cases

**Testing:**
- 17 unit tests (EventLogServiceTest) - enum conversion, pagination, filtering
- 13 integration tests (EventLogResourceIT) - validation, success scenarios, filtering
- Shared CaseHubIntegrationTestBase for test infrastructure
- All 106 tests passing (93 unit + 13 integration)

## Test Plan

- [x] All unit tests pass (93 tests)
- [x] All integration tests pass (13 tests for event log endpoint)
- [x] Full build succeeds (`mvn clean install`)
- [x] Error handling verified (400, 404, 500)
- [x] Pagination tested (default, custom, edge cases)
- [x] Filtering tested (eventType, streamType, combined)
- [x] Code quality review completed
- [x] Documentation complete (JavaDoc)

## Technical Details

**Pagination:**
- In-memory offset/limit after fetching from engine
- Max page size (1000) prevents memory abuse
- Handles empty results and out-of-bounds pages gracefully

**Filtering:**
- Engine supports: eventType only, eventType + streamType combined
- StreamType-only filtering uses in-memory filtering (engine limitation)
- Invalid enum values return 400 with clear error messages

**Error Handling:**
- Reactive pattern with .onFailure() chains
- ValidationException → 400 (pagination errors)
- IllegalArgumentException → 400 (invalid enum values)
- CaseInstanceNotFoundException → 404
- Generic Exception → 500
- All errors include ProblemDetail with descriptive messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)