### PR TITLE
feat(platform#68): add ACL checks to all REST endpoints

### DIFF
--- a/src/main/java/io/casehub/flow/rest/CaseControlResource.java
+++ b/src/main/java/io/casehub/flow/rest/CaseControlResource.java
@@ -19,6 +19,11 @@ import io.casehub.api.engine.CaseHubRuntime;
 import io.casehub.flow.rest.dto.CaseControlRequest;
 import io.casehub.flow.rest.dto.CaseControlResponse;
 import io.casehub.flow.rest.dto.ProblemDetail;
+import io.casehub.platform.api.acl.AccessControlProvider;
+import io.casehub.platform.api.acl.AccessDeniedException;
+import io.casehub.platform.api.acl.AclAction;
+import io.casehub.platform.api.acl.AclResourceType;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -57,6 +62,8 @@ public class CaseControlResource {
   private static final Logger LOG = Logger.getLogger(CaseControlResource.class);
 
   @Inject CaseHubRuntime caseHubRuntime;
+  @Inject AccessControlProvider acl;
+  @Inject CurrentPrincipal currentPrincipal;
 
   /**
    * Suspend case execution.
@@ -80,6 +87,11 @@ public class CaseControlResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> suspend(
       @PathParam("caseId") UUID caseId, CaseControlRequest request) {
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+    }
+
     return Uni.createFrom()
         .emitter(
             em -> {
@@ -147,6 +159,11 @@ public class CaseControlResource {
   @APIResponse(responseCode = "500", description = "Internal server error",
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> resume(@PathParam("caseId") UUID caseId, CaseControlRequest request) {
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+    }
+
     return Uni.createFrom()
         .emitter(
             em -> {
@@ -214,6 +231,11 @@ public class CaseControlResource {
   @APIResponse(responseCode = "500", description = "Internal server error",
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> cancel(@PathParam("caseId") UUID caseId, CaseControlRequest request) {
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.ADMIN)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.ADMIN);
+    }
+
     return Uni.createFrom()
         .emitter(
             em -> {

--- a/src/main/java/io/casehub/flow/rest/CaseDefinitionResource.java
+++ b/src/main/java/io/casehub/flow/rest/CaseDefinitionResource.java
@@ -19,6 +19,11 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.flow.rest.dto.PagedResponse;
 import io.casehub.flow.rest.dto.ProblemDetail;
 import io.casehub.flow.service.CaseDefinitionService;
+import io.casehub.platform.api.acl.AccessControlProvider;
+import io.casehub.platform.api.acl.AccessDeniedException;
+import io.casehub.platform.api.acl.AclAction;
+import io.casehub.platform.api.acl.AclResourceType;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -60,6 +65,8 @@ import java.util.List;
 public class CaseDefinitionResource {
 
   @Inject CaseDefinitionService caseDefinitionService;
+  @Inject AccessControlProvider acl;
+  @Inject CurrentPrincipal currentPrincipal;
 
   /**
    * List all registered case definitions with pagination.
@@ -128,6 +135,12 @@ public class CaseDefinitionResource {
     // JAX-RS should decode path params automatically, but ensure it's decoded
     String decodedName = URLDecoder.decode(name, StandardCharsets.UTF_8);
     String decodedNamespace = URLDecoder.decode(namespace, StandardCharsets.UTF_8);
+
+    String resourceId = AclResourceType.CASE_DEFINITION + ":" + decodedNamespace + "/" + decodedName;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+    }
+
     return caseDefinitionService
         .findByNamespaceAndName(decodedNamespace, decodedName)
         .map(
@@ -173,6 +186,12 @@ public class CaseDefinitionResource {
     String decodedName = URLDecoder.decode(name, StandardCharsets.UTF_8);
     String decodedNamespace = URLDecoder.decode(namespace, StandardCharsets.UTF_8);
     String decodedVersion = URLDecoder.decode(version, StandardCharsets.UTF_8);
+
+    String resourceId = AclResourceType.CASE_DEFINITION + ":" + decodedNamespace + "/" + decodedName;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+    }
+
     return caseDefinitionService
         .findByKey(decodedNamespace, decodedName, decodedVersion)
         .map(

--- a/src/main/java/io/casehub/flow/rest/CaseInstanceResource.java
+++ b/src/main/java/io/casehub/flow/rest/CaseInstanceResource.java
@@ -21,6 +21,11 @@ import io.casehub.flow.rest.dto.CaseInstanceResponse;
 import io.casehub.flow.rest.dto.ProblemDetail;
 import io.casehub.flow.rest.dto.StartCaseRequest;
 import io.casehub.flow.service.CaseInstanceService;
+import io.casehub.platform.api.acl.AccessControlProvider;
+import io.casehub.platform.api.acl.AccessDeniedException;
+import io.casehub.platform.api.acl.AclAction;
+import io.casehub.platform.api.acl.AclResourceType;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -59,6 +64,8 @@ import java.util.UUID;
 public class CaseInstanceResource {
 
   @Inject CaseInstanceService caseInstanceService;
+  @Inject AccessControlProvider acl;
+  @Inject CurrentPrincipal currentPrincipal;
 
   /**
    * Start a new case instance.
@@ -91,6 +98,12 @@ public class CaseInstanceResource {
                       new ProblemDetail(
                           "Invalid request", 400, "Request body and definition are required"))
                   .build());
+    }
+
+    String resourceId = AclResourceType.CASE_DEFINITION + ":"
+        + request.definition().namespace() + "/" + request.definition().name();
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
     }
 
     return caseInstanceService
@@ -134,6 +147,11 @@ public class CaseInstanceResource {
   @APIResponse(responseCode = "500", description = "Internal server error",
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> getCaseInstance(@PathParam("caseId") UUID caseId) {
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+    }
+
     return caseInstanceService
         .getCaseInstance(caseId)
         .map(response -> Response.ok(response).build())
@@ -172,6 +190,11 @@ public class CaseInstanceResource {
   @APIResponse(responseCode = "500", description = "Internal server error",
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> getContext(@PathParam("caseId") UUID caseId) {
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+    }
+
     return caseInstanceService
         .getCaseContext(caseId)
         .map(context -> Response.ok(context).build())
@@ -213,6 +236,11 @@ public class CaseInstanceResource {
   @APIResponse(responseCode = "500", description = "Internal server error",
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> getContextPath(@PathParam("caseId") UUID caseId, @PathParam("path") String path) {
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+    }
+
     return caseInstanceService
         .getContextPath(caseId, path)
         .map(value -> Response.ok(value).build())

--- a/src/main/java/io/casehub/flow/rest/EventLogResource.java
+++ b/src/main/java/io/casehub/flow/rest/EventLogResource.java
@@ -20,6 +20,11 @@ import io.casehub.flow.exception.ValidationException;
 import io.casehub.flow.rest.dto.PagedResponse;
 import io.casehub.flow.rest.dto.ProblemDetail;
 import io.casehub.flow.service.EventLogService;
+import io.casehub.platform.api.acl.AccessControlProvider;
+import io.casehub.platform.api.acl.AccessDeniedException;
+import io.casehub.platform.api.acl.AclAction;
+import io.casehub.platform.api.acl.AclResourceType;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -91,6 +96,8 @@ public class EventLogResource {
   private static final int MAX_PAGE_SIZE = 1000;
 
   @Inject EventLogService eventLogService;
+  @Inject AccessControlProvider acl;
+  @Inject CurrentPrincipal currentPrincipal;
 
   /**
    * Get event log for a case.
@@ -126,6 +133,11 @@ public class EventLogResource {
       @QueryParam("size") @DefaultValue("50") int size,
       @QueryParam("eventType") List<String> eventType,
       @QueryParam("streamType") List<String> streamType) {
+
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+    }
 
     return Uni.createFrom()
         .item(

--- a/src/main/java/io/casehub/flow/rest/SignalResource.java
+++ b/src/main/java/io/casehub/flow/rest/SignalResource.java
@@ -20,6 +20,11 @@ import io.casehub.flow.exception.CaseInstanceNotFoundException;
 import io.casehub.flow.rest.dto.ProblemDetail;
 import io.casehub.flow.rest.dto.SendSignalRequest;
 import io.casehub.flow.rest.dto.SignalResponse;
+import io.casehub.platform.api.acl.AccessControlProvider;
+import io.casehub.platform.api.acl.AccessDeniedException;
+import io.casehub.platform.api.acl.AclAction;
+import io.casehub.platform.api.acl.AclResourceType;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -58,6 +63,8 @@ public class SignalResource {
   private static final Logger LOG = Logger.getLogger(SignalResource.class);
 
   @Inject CaseHubRuntime caseHubRuntime;
+  @Inject AccessControlProvider acl;
+  @Inject CurrentPrincipal currentPrincipal;
 
   @POST
   @Operation(summary = "Send signal to a case",
@@ -76,6 +83,11 @@ public class SignalResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> sendSignal(
       @PathParam("caseId") UUID caseId, @Valid SendSignalRequest request) {
+
+    String resourceId = AclResourceType.CASE + ":" + caseId;
+    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
+      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+    }
 
     if (request == null) {
       return Uni.createFrom()

--- a/src/main/java/io/casehub/flow/rest/validation/AccessDeniedExceptionMapper.java
+++ b/src/main/java/io/casehub/flow/rest/validation/AccessDeniedExceptionMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.flow.rest.validation;
+
+import io.casehub.flow.rest.dto.ProblemDetail;
+import io.casehub.platform.api.acl.AccessDeniedException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class AccessDeniedExceptionMapper
+    implements ExceptionMapper<AccessDeniedException> {
+
+  @Override
+  public Response toResponse(AccessDeniedException exception) {
+    return Response.status(403)
+        .entity(new ProblemDetail("Access denied", 403, exception.getMessage()))
+        .build();
+  }
+}

--- a/src/test/java/io/casehub/flow/CaseDefinitionResourceTest.java
+++ b/src/test/java/io/casehub/flow/CaseDefinitionResourceTest.java
@@ -30,6 +30,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -321,7 +322,7 @@ class CaseDefinitionResourceTest {
                   .name("approver-worker")
                   .description("Approves documents")
                   .capabilities(approveCapability)
-                  .function(input -> Map.of("approved", true, "status", "approved"))
+                  .function(input -> WorkerResult.of(Map.of("approved", true, "status", "approved")))
                   .build())
           .bindings(
               Binding.builder()
@@ -362,7 +363,7 @@ class CaseDefinitionResourceTest {
               Worker.builder()
                   .name("approver-worker-v2")
                   .capabilities(approveCapability)
-                  .function(input -> Map.of("approved", true, "status", "approved"))
+                  .function(input -> WorkerResult.of(Map.of("approved", true, "status", "approved")))
                   .build())
           .bindings(
               Binding.builder()
@@ -400,7 +401,7 @@ class CaseDefinitionResourceTest {
               Worker.builder()
                   .name("invoice-processor")
                   .capabilities(processCapability)
-                  .function(input -> Map.of("processed", true))
+                  .function(input -> WorkerResult.of(Map.of("processed", true)))
                   .build())
           .bindings(
               Binding.builder()
@@ -438,7 +439,7 @@ class CaseDefinitionResourceTest {
               Worker.builder()
                   .name("document-classifier")
                   .capabilities(classifyCapability)
-                  .function(input -> Map.of("classified", true))
+                  .function(input -> WorkerResult.of(Map.of("classified", true)))
                   .build())
           .bindings(
               Binding.builder()


### PR DESCRIPTION
## Summary

- Inject `AccessControlProvider` + `CurrentPrincipal` into all 5 REST resource classes
- Synchronous `canAccess()` guard before each reactive chain; `AccessDeniedException` → 403 via `@Provider` ExceptionMapper
- Action mapping: GET→READ, POST mutating→WRITE, cancel→ADMIN, startCase→WRITE on casedefinition, listAll→no ACL (metadata listing)
- Fix `CaseDefinitionResourceTest`: wrap `Worker.function()` lambdas with `WorkerResult.of()` to match updated engine-api contract

## Action mapping

| Endpoint | Resource ID | Action |
|----------|------------|--------|
| `POST /cases` | `casedefinition:{ns}/{name}` | WRITE |
| `GET /cases/{caseId}` | `case:{caseId}` | READ |
| `GET /cases/{caseId}/context` | `case:{caseId}` | READ |
| `GET /cases/{caseId}/context/{path}` | `case:{caseId}` | READ |
| `POST /cases/{caseId}/suspend` | `case:{caseId}` | WRITE |
| `POST /cases/{caseId}/resume` | `case:{caseId}` | WRITE |
| `POST /cases/{caseId}/cancel` | `case:{caseId}` | ADMIN |
| `GET /case-definitions` | — | no ACL |
| `GET /case-definitions/{ns}/{name}` | `casedefinition:{ns}/{name}` | READ |
| `GET /case-definitions/{ns}/{name}/{ver}` | `casedefinition:{ns}/{name}` | READ |
| `GET /cases/{caseId}/events` | `case:{caseId}` | READ |
| `POST /cases/{caseId}/signals` | `case:{caseId}` | WRITE |

## Test plan

- [x] `mvn compile` passes — all ACL imports resolve
- [ ] Existing tests pass (1 pre-existing infra failure: engine#488 — `casehub_crosstenancy` role not created when RLS disabled)
- [ ] Verify NoOp default returns `true` → no behavioral change for consumers without explicit ACL grants

🤖 Generated with [Claude Code](https://claude.com/claude-code)