### PR TITLE
feat(platform#91): ACL integration tests with JWT identity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
         <dependency>
             <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-flow</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
             <artifactId>casehub-work</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -146,6 +152,23 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-platform-acl-jpa</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-platform-oidc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security-oidc</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/casehub/flow/rest/CaseControlResource.java
+++ b/src/main/java/io/casehub/flow/rest/CaseControlResource.java
@@ -88,25 +88,25 @@ public class CaseControlResource {
   public Uni<Response> suspend(
       @PathParam("caseId") UUID caseId, CaseControlRequest request) {
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
-    }
 
-    return Uni.createFrom()
-        .emitter(
-            em -> {
-              try {
-                if (request != null && request.reason() != null) {
-                  LOG.infof("Suspending case %s, reason: %s", caseId, request.reason());
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+          return Uni.createFrom().emitter(
+              em -> {
+                try {
+                  if (request != null && request.reason() != null) {
+                    LOG.infof("Suspending case %s, reason: %s", caseId, request.reason());
+                  }
+                  caseHubRuntime.suspendCase(caseId);
+                  em.complete(
+                      new CaseControlResponse(
+                          caseId, "suspend", "accepted", "Case suspension queued for processing"));
+                } catch (Exception e) {
+                  em.fail(e);
                 }
-                caseHubRuntime.suspendCase(caseId);
-                em.complete(
-                    new CaseControlResponse(
-                        caseId, "suspend", "accepted", "Case suspension queued for processing"));
-              } catch (Exception e) {
-                em.fail(e);
-              }
-            })
+              });
+        })
         .map(response -> Response.status(202).entity(response).build())
         .onFailure(IllegalArgumentException.class)
         .recoverWithItem(
@@ -124,7 +124,7 @@ public class CaseControlResource {
                   .entity(new ProblemDetail("Invalid state transition", 409, ex.getMessage()))
                   .build();
             })
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex -> {
               LOG.errorf(ex, "Failed to suspend case %s", caseId);
@@ -160,25 +160,25 @@ public class CaseControlResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> resume(@PathParam("caseId") UUID caseId, CaseControlRequest request) {
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
-    }
 
-    return Uni.createFrom()
-        .emitter(
-            em -> {
-              try {
-                if (request != null && request.reason() != null) {
-                  LOG.infof("Resuming case %s, reason: %s", caseId, request.reason());
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+          return Uni.createFrom().emitter(
+              em -> {
+                try {
+                  if (request != null && request.reason() != null) {
+                    LOG.infof("Resuming case %s, reason: %s", caseId, request.reason());
+                  }
+                  caseHubRuntime.resumeCase(caseId);
+                  em.complete(
+                      new CaseControlResponse(
+                          caseId, "resume", "accepted", "Case resumption queued for processing"));
+                } catch (Exception e) {
+                  em.fail(e);
                 }
-                caseHubRuntime.resumeCase(caseId);
-                em.complete(
-                    new CaseControlResponse(
-                        caseId, "resume", "accepted", "Case resumption queued for processing"));
-              } catch (Exception e) {
-                em.fail(e);
-              }
-            })
+              });
+        })
         .map(response -> Response.status(202).entity(response).build())
         .onFailure(IllegalArgumentException.class)
         .recoverWithItem(
@@ -196,7 +196,7 @@ public class CaseControlResource {
                   .entity(new ProblemDetail("Invalid state transition", 409, ex.getMessage()))
                   .build();
             })
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex -> {
               LOG.errorf(ex, "Failed to resume case %s", caseId);
@@ -232,25 +232,25 @@ public class CaseControlResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> cancel(@PathParam("caseId") UUID caseId, CaseControlRequest request) {
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.ADMIN)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.ADMIN);
-    }
 
-    return Uni.createFrom()
-        .emitter(
-            em -> {
-              try {
-                if (request != null && request.reason() != null) {
-                  LOG.infof("Cancelling case %s, reason: %s", caseId, request.reason());
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.ADMIN))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.ADMIN);
+          return Uni.createFrom().emitter(
+              em -> {
+                try {
+                  if (request != null && request.reason() != null) {
+                    LOG.infof("Cancelling case %s, reason: %s", caseId, request.reason());
+                  }
+                  caseHubRuntime.cancelCase(caseId);
+                  em.complete(
+                      new CaseControlResponse(
+                          caseId, "cancel", "accepted", "Case cancellation queued for processing"));
+                } catch (Exception e) {
+                  em.fail(e);
                 }
-                caseHubRuntime.cancelCase(caseId);
-                em.complete(
-                    new CaseControlResponse(
-                        caseId, "cancel", "accepted", "Case cancellation queued for processing"));
-              } catch (Exception e) {
-                em.fail(e);
-              }
-            })
+              });
+        })
         .map(response -> Response.status(202).entity(response).build())
         .onFailure(IllegalArgumentException.class)
         .recoverWithItem(
@@ -268,7 +268,7 @@ public class CaseControlResource {
                   .entity(new ProblemDetail("Invalid state transition", 409, ex.getMessage()))
                   .build();
             })
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex -> {
               LOG.errorf(ex, "Failed to cancel case %s", caseId);

--- a/src/main/java/io/casehub/flow/rest/CaseDefinitionResource.java
+++ b/src/main/java/io/casehub/flow/rest/CaseDefinitionResource.java
@@ -137,12 +137,12 @@ public class CaseDefinitionResource {
     String decodedNamespace = URLDecoder.decode(namespace, StandardCharsets.UTF_8);
 
     String resourceId = AclResourceType.CASE_DEFINITION + ":" + decodedNamespace + "/" + decodedName;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
-    }
 
-    return caseDefinitionService
-        .findByNamespaceAndName(decodedNamespace, decodedName)
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+          return caseDefinitionService.findByNamespaceAndName(decodedNamespace, decodedName);
+        })
         .map(
             definitions -> {
               if (definitions.isEmpty()) {
@@ -188,12 +188,12 @@ public class CaseDefinitionResource {
     String decodedVersion = URLDecoder.decode(version, StandardCharsets.UTF_8);
 
     String resourceId = AclResourceType.CASE_DEFINITION + ":" + decodedNamespace + "/" + decodedName;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
-    }
 
-    return caseDefinitionService
-        .findByKey(decodedNamespace, decodedName, decodedVersion)
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+          return caseDefinitionService.findByKey(decodedNamespace, decodedName, decodedVersion);
+        })
         .map(
             definition -> {
               if (definition == null) {

--- a/src/main/java/io/casehub/flow/rest/CaseInstanceResource.java
+++ b/src/main/java/io/casehub/flow/rest/CaseInstanceResource.java
@@ -102,12 +102,12 @@ public class CaseInstanceResource {
 
     String resourceId = AclResourceType.CASE_DEFINITION + ":"
         + request.definition().namespace() + "/" + request.definition().name();
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
-    }
 
-    return caseInstanceService
-        .startCase(request)
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+          return caseInstanceService.startCase(request);
+        })
         .map(response -> Response.ok(response).build())
         .onFailure(DefinitionNotFoundException.class)
         .recoverWithItem(
@@ -117,7 +117,7 @@ public class CaseInstanceResource {
                         new ProblemDetail(
                             "Case definition not found", 404, ex.getMessage()))
                     .build())
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex ->
                 Response.status(500)
@@ -148,12 +148,12 @@ public class CaseInstanceResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> getCaseInstance(@PathParam("caseId") UUID caseId) {
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
-    }
 
-    return caseInstanceService
-        .getCaseInstance(caseId)
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+          return caseInstanceService.getCaseInstance(caseId);
+        })
         .map(response -> Response.ok(response).build())
         .onFailure(CaseInstanceNotFoundException.class)
         .recoverWithItem(
@@ -163,7 +163,7 @@ public class CaseInstanceResource {
                         new ProblemDetail(
                             "Case instance not found", 404, ex.getMessage()))
                     .build())
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex ->
                 Response.status(500)
@@ -191,12 +191,12 @@ public class CaseInstanceResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> getContext(@PathParam("caseId") UUID caseId) {
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
-    }
 
-    return caseInstanceService
-        .getCaseContext(caseId)
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+          return caseInstanceService.getCaseContext(caseId);
+        })
         .map(context -> Response.ok(context).build())
         .onFailure(CaseInstanceNotFoundException.class)
         .recoverWithItem(
@@ -206,7 +206,7 @@ public class CaseInstanceResource {
                         new ProblemDetail(
                             "Case instance not found", 404, ex.getMessage()))
                     .build())
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex ->
                 Response.status(500)
@@ -237,12 +237,12 @@ public class CaseInstanceResource {
                content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
   public Uni<Response> getContextPath(@PathParam("caseId") UUID caseId, @PathParam("path") String path) {
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
-    }
 
-    return caseInstanceService
-        .getContextPath(caseId, path)
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+          return caseInstanceService.getContextPath(caseId, path);
+        })
         .map(value -> Response.ok(value).build())
         .onFailure(CaseInstanceNotFoundException.class)
         .recoverWithItem(
@@ -252,7 +252,7 @@ public class CaseInstanceResource {
                         new ProblemDetail(
                             "Case instance not found", 404, ex.getMessage()))
                     .build())
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex ->
                 Response.status(500)

--- a/src/main/java/io/casehub/flow/rest/EventLogResource.java
+++ b/src/main/java/io/casehub/flow/rest/EventLogResource.java
@@ -135,22 +135,15 @@ public class EventLogResource {
       @QueryParam("streamType") List<String> streamType) {
 
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
-    }
 
-    return Uni.createFrom()
-        .item(
-            () -> {
-              // Validate parameters (throws ValidationException on failure)
-              validatePaginationParams(page, size);
-              eventLogService.convertEventTypes(eventType); // throws IllegalArgumentException
-              eventLogService.convertStreamTypes(streamType); // throws IllegalArgumentException
-              return true;
-            })
-        .flatMap(
-            ignored ->
-                eventLogService.getEventLog(caseId, page, size, eventType, streamType))
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.READ))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.READ);
+          validatePaginationParams(page, size);
+          eventLogService.convertEventTypes(eventType);
+          eventLogService.convertStreamTypes(streamType);
+          return eventLogService.getEventLog(caseId, page, size, eventType, streamType);
+        })
         .map(pagedResponse -> Response.ok(pagedResponse).build())
         .onFailure(ValidationException.class)
         .recoverWithItem(
@@ -181,7 +174,7 @@ public class EventLogResource {
                       new ProblemDetail("Case instance not found", 404, ex.getMessage()))
                   .build();
             })
-        .onFailure()
+        .onFailure(ex -> !(ex instanceof AccessDeniedException))
         .recoverWithItem(
             ex -> {
               LOG.errorf(ex, "Failed to retrieve event log for case %s", caseId);

--- a/src/main/java/io/casehub/flow/rest/SignalResource.java
+++ b/src/main/java/io/casehub/flow/rest/SignalResource.java
@@ -85,9 +85,6 @@ public class SignalResource {
       @PathParam("caseId") UUID caseId, @Valid SendSignalRequest request) {
 
     String resourceId = AclResourceType.CASE + ":" + caseId;
-    if (!acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE)) {
-      throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
-    }
 
     if (request == null) {
       return Uni.createFrom()
@@ -101,9 +98,11 @@ public class SignalResource {
                   .build());
     }
 
-    // Validate case exists and send signal
-    return Uni.createFrom()
-        .completionStage(() -> caseHubRuntime.query(caseId, ".", Object.class))
+    return Uni.createFrom().completionStage(acl.canAccess(currentPrincipal.actorId(), resourceId, AclAction.WRITE))
+        .flatMap(allowed -> {
+          if (!allowed) throw new AccessDeniedException(currentPrincipal.actorId(), resourceId, AclAction.WRITE);
+          return Uni.createFrom().completionStage(() -> caseHubRuntime.query(caseId, ".", Object.class));
+        })
         .map(
             ignored -> {
               caseHubRuntime.signal(caseId, request.path(), request.value());
@@ -118,7 +117,7 @@ public class SignalResource {
                   .entity(new ProblemDetail("Case not found", 404, ex.getMessage()))
                   .build();
             })
-        .onFailure(RuntimeException.class)
+        .onFailure(ex -> ex instanceof RuntimeException && !(ex instanceof AccessDeniedException))
         .recoverWithUni(
             ex -> {
               if (ex.getMessage() != null && ex.getMessage().contains("not found")) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,6 +55,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 %test.quarkus.flyway.migrate-at-start=false
 %test.quarkus.quartz.store-type=ram
 %test.casehub.engine.worker.default-timeout-ms=2000
+%test.quarkus.arc.exclude-types=io.casehub.platform.acl.jpa.JpaAccessControlProvider,io.casehub.platform.oidc.OidcCurrentPrincipal,io.casehub.work.runtime.service.NoOpGroupMembershipProvider,io.casehub.work.runtime.service.TenantScopedPrincipal,io.casehub.flow.profile.JwtAwareTestPrincipal
 
 # ============================================================================
 # OpenAPI / Swagger UI

--- a/src/test/java/io/casehub/flow/profile/JwtAclTestProfile.java
+++ b/src/test/java/io/casehub/flow/profile/JwtAclTestProfile.java
@@ -1,0 +1,23 @@
+package io.casehub.flow.profile;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+/**
+ * Test profile that activates JPA-backed ACL + JWT-aware CurrentPrincipal.
+ *
+ * <p>JwtAwareTestPrincipal reads actorId/tenancyId/groups from SecurityIdentity and JWT
+ * claims populated by @TestSecurity + @OidcSecurity annotations. Falls back to config
+ * properties during startup.
+ */
+public class JwtAclTestProfile implements QuarkusTestProfile {
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of(
+        "quarkus.arc.exclude-types",
+        "io.casehub.platform.oidc.OidcCurrentPrincipal,io.casehub.work.runtime.service.NoOpGroupMembershipProvider,io.casehub.work.runtime.service.TenantScopedPrincipal",
+        "casehub.platform.principal.actorId", "test-actor",
+        "casehub.tenancy.default-id", "test-tenant");
+  }
+}

--- a/src/test/java/io/casehub/flow/profile/JwtAwareTestPrincipal.java
+++ b/src/test/java/io/casehub/flow/profile/JwtAwareTestPrincipal.java
@@ -1,0 +1,84 @@
+package io.casehub.flow.profile;
+
+import io.casehub.platform.api.identity.CurrentPrincipal;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.Set;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * Test-only CurrentPrincipal that reads identity from SecurityIdentity/JWT when a request
+ * context is active (populated by @TestSecurity + @OidcSecurity), and falls back to config
+ * properties during startup when no request scope exists.
+ *
+ * <p>Excluded by default via quarkus.arc.exclude-types — activated only in profiles that
+ * omit it from the exclusion list.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class JwtAwareTestPrincipal implements CurrentPrincipal {
+
+  @Inject SecurityIdentity identity;
+  @Inject JsonWebToken jwt;
+
+  @ConfigProperty(name = "casehub.platform.principal.actorId", defaultValue = "anonymous")
+  String fallbackActorId;
+
+  @ConfigProperty(name = "casehub.tenancy.default-id", defaultValue = "default")
+  String fallbackTenancyId;
+
+  @Override
+  public String actorId() {
+    try {
+      if (!identity.isAnonymous()) {
+        return identity.getPrincipal().getName();
+      }
+    } catch (Exception e) {
+      return fallbackActorId;
+    }
+    return fallbackActorId;
+  }
+
+  @Override
+  public Set<String> groups() {
+    try {
+      if (!identity.isAnonymous()) {
+        return identity.getRoles();
+      }
+    } catch (Exception e) {
+      return Set.of();
+    }
+    return Set.of();
+  }
+
+  @Override
+  public String tenancyId() {
+    try {
+      if (!identity.isAnonymous()) {
+        Object claim = jwt.getClaim("tenancyId");
+        if (claim != null) return claim.toString();
+      }
+    } catch (Exception e) {
+      return fallbackTenancyId;
+    }
+    return fallbackTenancyId;
+  }
+
+  @Override
+  public boolean isCrossTenantAdmin() {
+    try {
+      if (!identity.isAnonymous()) {
+        Boolean claim = jwt.getClaim("crossTenantAdmin");
+        return Boolean.TRUE.equals(claim);
+      }
+    } catch (Exception e) {
+      return false;
+    }
+    return false;
+  }
+}

--- a/src/test/java/io/casehub/flow/rest/AclIntegrationTest.java
+++ b/src/test/java/io/casehub/flow/rest/AclIntegrationTest.java
@@ -1,0 +1,404 @@
+package io.casehub.flow.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.casehub.flow.profile.JwtAclTestProfile;
+import io.casehub.platform.api.acl.AccessControlProvider;
+import io.casehub.platform.api.acl.AclAction;
+import io.casehub.platform.api.acl.AclResourceType;
+import io.casehub.platform.api.identity.CurrentPrincipal;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.OidcSecurity;
+import jakarta.inject.Inject;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(JwtAclTestProfile.class)
+class AclIntegrationTest {
+
+  private static final String ACTOR_ID = "test-actor";
+  private static final String TENANT_ID = "test-tenant";
+  private static final UUID CASE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  @Inject AccessControlProvider acl;
+  @Inject CurrentPrincipal currentPrincipal;
+
+  // --- Config-based principal (fallback, no @TestSecurity) ---
+
+  @Test
+  void testPrincipalConfigured() {
+    assertThat(currentPrincipal.actorId()).isEqualTo(ACTOR_ID);
+    assertThat(currentPrincipal.tenancyId()).isEqualTo(TENANT_ID);
+  }
+
+  // --- CaseDefinitionResource ---
+
+  @Test
+  void testDenyReadDefinitionByNamespaceAndName() {
+    given()
+        .when()
+        .get("/api/v1/case-definitions/deny-ns/deny-def")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testDenyReadDefinitionByVersion() {
+    given()
+        .when()
+        .get("/api/v1/case-definitions/deny-ns/deny-def-v/1.0.0")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testAllowReadDefinitionAfterGrant() {
+    String resourceId = AclResourceType.CASE_DEFINITION + ":allow-ns/allow-def";
+    acl.grant(ACTOR_ID, resourceId, AclAction.READ, null).toCompletableFuture().join();
+
+    given()
+        .when()
+        .get("/api/v1/case-definitions/allow-ns/allow-def")
+        .then()
+        .statusCode(404);
+  }
+
+  // --- CaseInstanceResource ---
+
+  @Test
+  void testDenyStartCase() {
+    given()
+        .contentType("application/json")
+        .body("""
+            {
+              "definition": {
+                "namespace": "deny-ns",
+                "name": "deny-case",
+                "version": "1.0.0"
+              }
+            }
+            """)
+        .when()
+        .post("/api/v1/cases")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testDenyGetCaseInstance() {
+    given()
+        .when()
+        .get("/api/v1/cases/" + CASE_ID)
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testDenyGetCaseContext() {
+    given()
+        .when()
+        .get("/api/v1/cases/" + CASE_ID + "/context")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testDenyGetCaseContextByPath() {
+    given()
+        .when()
+        .get("/api/v1/cases/" + CASE_ID + "/context/some.path")
+        .then()
+        .statusCode(403);
+  }
+
+  // --- CaseControlResource ---
+
+  @Test
+  void testDenySuspendCase() {
+    given()
+        .contentType("application/json")
+        .body("{}")
+        .when()
+        .post("/api/v1/cases/" + CASE_ID + "/suspend")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testDenyResumeCase() {
+    given()
+        .contentType("application/json")
+        .body("{}")
+        .when()
+        .post("/api/v1/cases/" + CASE_ID + "/resume")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void testDenyCancelCase() {
+    given()
+        .contentType("application/json")
+        .body("{}")
+        .when()
+        .post("/api/v1/cases/" + CASE_ID + "/cancel")
+        .then()
+        .statusCode(403);
+  }
+
+  // --- SignalResource ---
+
+  @Test
+  void testDenySendSignal() {
+    given()
+        .contentType("application/json")
+        .body("""
+            {
+              "path": "some.path",
+              "value": "test"
+            }
+            """)
+        .when()
+        .post("/api/v1/cases/" + CASE_ID + "/signals")
+        .then()
+        .statusCode(403);
+  }
+
+  // --- EventLogResource ---
+
+  @Test
+  void testDenyGetEventLog() {
+    given()
+        .when()
+        .get("/api/v1/cases/" + CASE_ID + "/events")
+        .then()
+        .statusCode(403);
+  }
+
+  // --- JWT identity via @TestSecurity + @OidcSecurity ---
+
+  @Test
+  @TestSecurity(user = "jwt-actor", roles = {"admin"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "jwt-tenant"))
+  void testJwtClaimsPopulatePrincipal() {
+    assertThat(currentPrincipal.actorId()).isEqualTo("jwt-actor");
+    assertThat(currentPrincipal.tenancyId()).isEqualTo("jwt-tenant");
+    assertThat(currentPrincipal.groups()).contains("admin");
+  }
+
+  @Test
+  @TestSecurity(user = "jwt-actor", roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "jwt-tenant"))
+  void testDenyWithJwtIdentity() {
+    given()
+        .when()
+        .get("/api/v1/case-definitions/jwt-deny-ns/jwt-deny-def")
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  @TestSecurity(user = "jwt-actor", roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "jwt-tenant"))
+  void testAllowAfterGrantWithJwtIdentity() {
+    String resourceId = AclResourceType.CASE_DEFINITION + ":jwt-ns/jwt-def";
+    acl.grant("jwt-actor", resourceId, AclAction.READ, null).toCompletableFuture().join();
+
+    given()
+        .when()
+        .get("/api/v1/case-definitions/jwt-ns/jwt-def")
+        .then()
+        .statusCode(404);
+  }
+
+  // --- JWT positive: grant + verify real response data ---
+
+  private static final String JWT_ACTOR = "jwt-actor";
+  private static final String DEF_NS = "test-yaml";
+  private static final String DEF_NAME = "YAML Test Case";
+  private static final String DEF_VERSION = "1.0.0";
+  private static final String DEF_RESOURCE =
+      AclResourceType.CASE_DEFINITION + ":" + DEF_NS + "/" + DEF_NAME;
+
+  private String startCaseAsJwtActor() {
+    acl.grant(JWT_ACTOR, DEF_RESOURCE, AclAction.WRITE, null).toCompletableFuture().join();
+
+    String caseId =
+        given()
+            .contentType("application/json")
+            .body(
+                """
+            {"definition":{"namespace":"%s","name":"%s","version":"%s"}}
+            """
+                    .formatted(DEF_NS, DEF_NAME, DEF_VERSION))
+            .when()
+            .post("/api/v1/cases")
+            .then()
+            .statusCode(200)
+            .extract()
+            .path("caseId");
+
+    String caseResource = AclResourceType.CASE + ":" + caseId;
+    acl.grant(JWT_ACTOR, caseResource, AclAction.READ, null).toCompletableFuture().join();
+    acl.grant(JWT_ACTOR, caseResource, AclAction.WRITE, null).toCompletableFuture().join();
+    acl.grant(JWT_ACTOR, caseResource, AclAction.ADMIN, null).toCompletableFuture().join();
+
+    return caseId;
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testReadDefinitionWithJwt() {
+    acl.grant(JWT_ACTOR, DEF_RESOURCE, AclAction.READ, null).toCompletableFuture().join();
+
+    given()
+        .when()
+        .get("/api/v1/case-definitions/" + DEF_NS + "/" + DEF_NAME)
+        .then()
+        .statusCode(200)
+        .body("[0].namespace", equalTo(DEF_NS))
+        .body("[0].name", equalTo(DEF_NAME));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testReadDefinitionByVersionWithJwt() {
+    acl.grant(JWT_ACTOR, DEF_RESOURCE, AclAction.READ, null).toCompletableFuture().join();
+
+    given()
+        .when()
+        .get("/api/v1/case-definitions/" + DEF_NS + "/" + DEF_NAME + "/" + DEF_VERSION)
+        .then()
+        .statusCode(200)
+        .body("namespace", equalTo(DEF_NS))
+        .body("version", equalTo(DEF_VERSION));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testStartCaseWithJwt() {
+    acl.grant(JWT_ACTOR, DEF_RESOURCE, AclAction.WRITE, null).toCompletableFuture().join();
+
+    given()
+        .contentType("application/json")
+        .body(
+            """
+            {"definition":{"namespace":"%s","name":"%s","version":"%s"}}
+            """
+                .formatted(DEF_NS, DEF_NAME, DEF_VERSION))
+        .when()
+        .post("/api/v1/cases")
+        .then()
+        .statusCode(200)
+        .body("caseId", notNullValue())
+        .body("status", equalTo("RUNNING"))
+        .body("namespace", equalTo(DEF_NS))
+        .body("name", equalTo(DEF_NAME));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testGetCaseInstanceWithJwt() {
+    String caseId = startCaseAsJwtActor();
+
+    given()
+        .when()
+        .get("/api/v1/cases/" + caseId)
+        .then()
+        .statusCode(200)
+        .body("caseId", equalTo(caseId))
+        .body("status", notNullValue())
+        .body("namespace", equalTo(DEF_NS));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testGetCaseContextWithJwt() {
+    String caseId = startCaseAsJwtActor();
+
+    given()
+        .when()
+        .get("/api/v1/cases/" + caseId + "/context")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testSuspendCaseWithJwt() {
+    String caseId = startCaseAsJwtActor();
+
+    given()
+        .contentType("application/json")
+        .body("{}")
+        .when()
+        .post("/api/v1/cases/" + caseId + "/suspend")
+        .then()
+        .statusCode(202)
+        .body("caseId", equalTo(caseId))
+        .body("operation", equalTo("suspend"));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testCancelCaseWithJwt() {
+    String caseId = startCaseAsJwtActor();
+
+    given()
+        .contentType("application/json")
+        .body("{}")
+        .when()
+        .post("/api/v1/cases/" + caseId + "/cancel")
+        .then()
+        .statusCode(202)
+        .body("caseId", equalTo(caseId))
+        .body("operation", equalTo("cancel"));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testSendSignalWithJwt() {
+    String caseId = startCaseAsJwtActor();
+
+    given()
+        .contentType("application/json")
+        .body("""
+            {"path": "data", "value": "signal-value"}
+            """)
+        .when()
+        .post("/api/v1/cases/" + caseId + "/signals")
+        .then()
+        .statusCode(202)
+        .body("caseId", equalTo(caseId))
+        .body("status", equalTo("accepted"));
+  }
+
+  @Test
+  @TestSecurity(user = JWT_ACTOR, roles = {"user"})
+  @OidcSecurity(claims = @Claim(key = "tenancyId", value = "test-tenant"))
+  void testGetEventLogWithJwt() {
+    String caseId = startCaseAsJwtActor();
+
+    given()
+        .when()
+        .get("/api/v1/cases/" + caseId + "/events")
+        .then()
+        .statusCode(200)
+        .body("page", equalTo(1));
+  }
+}


### PR DESCRIPTION
## Summary

- Add ACL checks to all REST endpoints (CaseDefinition, CaseInstance, CaseControl, Signal, EventLog)
- Add `AccessDeniedExceptionMapper` for 403 responses
- Add `JwtAwareTestPrincipal` — `@Alternative @Priority(1)` that reads actorId/tenancyId/groups from JWT claims, falls back to config during startup
- Add `AclIntegrationTest` with 25 tests: 12 deny tests, 3 JWT identity tests, 9 positive lifecycle tests with real case start/suspend/cancel/signal/events
- Add `JwtAclTestProfile` for test isolation

Depends on: casehubio/platform#106 (async ACL API)

## Test plan

- [x] 25 tests pass (`mvn test -Dtest=AclIntegrationTest`)
- [x] Config-based principal fallback verified
- [x] JWT claims override verified (`jwt-tenant` identity tests)
- [x] All deny paths return 403
- [x] All positive paths start real cases and verify response bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)